### PR TITLE
xt-72 SDK is observing on construction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ class AddonsSdk {
 
   public locale: Locale = Locale.ENGLISH;
 
+  public activeListener: boolean = false;
+
   public theme: Theme = Theme.LIGHT;
 
   public userIdentifier?: string;
@@ -94,8 +96,6 @@ class AddonsSdk {
         context: [JSON.stringify(message)]
       });
     };
-
-    window.addEventListener('message', this.handleReceivedMessage);
   }
 
   /**
@@ -105,6 +105,11 @@ class AddonsSdk {
    * @memberof AddonsSdk
    */
   public ready () {
+    if (!this.activeListener) {
+      this.activeListener = true;
+      window.addEventListener('message', this.handleReceivedMessage);
+    }
+
     const postMessage = JSON.stringify(
       new AddonMessage(AddonMessageType.READY)
     );


### PR DESCRIPTION
In order to enable using of the types from the SDK without the unexpected impact on the host, we are moving subscriptions to received messages from the constructor to ready() 