### PR TITLE
XT-89 Adding manifest support for configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,109 @@
+<!-- omit in toc -->
+# Addon configuration
+
+Some of the add-ons require a user-specific configuration to be initialized properly.
+
+That configuration contains one or more user values either when the user installed the add-on or at the moment of first interaction (if the add-on was installed for the user by an admin).
+
+Add-on creator needs to define in manifest what are the configuration values Outreach needs to collect for them, and Outreach will then construct a UI component that will gather and persist configuration data from the user. 
+Outreach application will send to add-on all of those collected with every add-on initialization.
+
+- [Manifest configuration definition](#manifest-configuration-definition)
+  - [Example configuration section](#example-configuration-section)
+  - [Configuration items](#configuration-items)
+    - [key](#key)
+    - [text](#text)
+    - [type](#type)
+    - [required](#required)
+    - [validator](#validator)
+    - [defaultValue](#defaultvalue)
+    - [options](#options)
+    - [urlInclude](#urlinclude)
+  - [Configuration values](#configuration-values)
+    - [URL support](#url-support)
+    - [SDK support](#sdk-support)
+
+## Manifest configuration definition
+
+The manifest has to have a configuration section that will describe the Outreach app's values add-on needs to initialize.
+
+The configuration section contains zero or more configuration items.
+
+### Example configuration section
+
+Let's look at an example of an add-on that requires Outreach users to visit the add-on creator web site and obtain their client id, key, and secret for accessing add-on creator APIs. Those values add-on expects Outreach to provide during the add-on initialization, so add-on can use them to access its APIs in the context of Outreach user.
+
+The add-on creator will add a config section into the manifest with three configuration items to achieve this.
+
+```json
+manifest: {
+  configuration: [
+    { key: 'clientId', text: { en: 'Enter client id' }, type: 'string', required: true, urlInclude: true },
+    { key: 'clientKey', text: { en: 'Enter client secret' }, type: 'string', required: true, urlInclude: false },
+    { key: 'clientSecret', text: { en: 'Enter client key' }, type: 'string', required: true, urlInclude: false }
+  ]
+}
+
+```
+
+### Configuration items
+
+Every configuration item has a list of properties describing the type of configuration data being collected, which is then used by the Outreach app to render relevant UI components collecting that data.
+
+#### key
+
+Keycode of the configuration value. It is sent as a part of the add-on initialization context, and through the URL, so it is recommended to be short.
+
+#### text
+
+Localized text of the label text is shown to a user explaining the configuration value the user needs to provide.
+
+#### type
+
+Type of the configuration value data defining the type of UI component used to collect this configuration value.
+string - regular input control
+
+- number - input type="number"
+- date - input type="date"
+- uri - input type="url"
+- options - multi-select control producing an array of option values
+- select - single select control selecting one of the possible configs
+
+#### required
+
+Define if the config value is mandatory and has to be provided by the user.
+
+#### validator
+
+Represents an optional regex expression that will be used to validate the configuration value entered by the user.
+
+#### defaultValue
+
+Represents an optional default value to be offered to the user by default when the configuration component loads
+
+#### options
+
+An optional collection of values is presented to the user if the type is 'options' or 'select' from which the user selects one or more options.
+
+#### urlInclude
+
+Represents a value defining if the Outreach app will pass the configuration value through the URL in addition to the initialization message.
+
+### Configuration values
+
+Configuration value is a combination of key and value where the key is [configuationItem.key](#key), and value is value Outreach user-entered before the add-on loads.
+
+Those values are passes to addon through url and add-on sdk initialization event.
+
+#### URL support
+
+As you can see in the example above, the clientId value is an example of the value passed through UI as an add-on will need it very early.
+The url used for loading will have an additional parameter for clientId
+
+```http
+http://some-site.com/addon?...&clientId=a12345
+```
+
+#### SDK support
+
+All of the configuration values are sent to addon through the addon [initilization message config property](https://github.com/getoutreach/clientxtsdk/blob/master/docs/sdk.md#init-event-handler).

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -18,6 +18,7 @@ Table of content:
   - [author](#author)
 - [Integration manifest properties](#integration-manifest-properties)
   - [context](#context)
+- [configuration](#configuration)
 - [api (optional)](#api-optional)
   - [applicationId](#applicationid)
   - [redirectUri](#redirecturi)
@@ -32,37 +33,65 @@ Here is the sample manifest file of the hello world addon
 
 ```json
 {
-    "version": "0.10",
-    "identifier": "addon-outreach-hello",
-    "store": "public",
-    "title":  [
-        "en": "Hello world",
-        "fr": "Salut tout le monde"
-    ],
-    "description": [
-        "en": "This is a sample addon created as a guide for Outreach addon creators ",
-        "fr": "Il s’agit d’un addon échantillon créé comme
-               un guide pour les créateurs addon Outreach",
-    ],
-    "host": {
-        "type": "tab-opportunity",
-        "url": "https://addon-host.com/something",
-        "icon": "https://addon-host.com/icon.png"
+  "version": "0.10",
+  "identifier": "addon-outreach-hello",
+  "store": "public",
+  "title": [
+    "en": "Hello world",
+    "fr": "Salut tout le monde"
+  ],
+  "description": [
+    "en": "This is a sample addon created as a guide for Outreach addon creators ",
+    "fr": "Il s’agit d’un addon échantillon créé comme
+    un guide pour les créateurs addon Outreach ",
+  ],
+  "host": {
+    "type": "tab-opportunity",
+    "url": "https://addon-host.com/something",
+    "icon": "https://addon-host.com/icon.png"
+  },
+  "author": {
+    "websiteUrl": "https://addon-host.com",
+    "privacyUrl": "https://addon-host.com/privacy",
+    "termsOfUseUrl": "https://addon-host.com/tos",
+  },
+  "context": [
+    "usr.id", "opp.id", "prospect.emails"
+  ],
+  "api": {
+    "token": "https://addon-host.com/token",
+    "scopes": "prospects.read, opportunity.read",
+    "applicationId": "AbCd123456qW",
+    "redirectUri": "https://addon-host.com/hello-world",
+  },
+  "configuration": [{
+      "key": "clientId",
+      "text": {
+        "en": "Enter client id"
+      },
+      "type": "string",
+      "required": true,
+      "urlInclude": true
     },
-    "author": {
-        "websiteUrl": "https://addon-host.com",
-        "privacyUrl": "https://addon-host.com/privacy",
-        "termsOfUseUrl": "https://addon-host.com/tos",
+    {
+      "key": "clientKey",
+      "text": {
+        "en": "Enter client secret"
+      },
+      "type": "string",
+      "required": true,
+      "urlInclude": false
     },
-    "context":  [
-      "usr.id", "opp.id", "prospect.emails"
-    ],
-    "api": {
-      "token": "https://addon-host.com/token",
-      "scopes": "prospects.read, opportunity.read",
-      "applicationId": "AbCd123456qW",
-      "redirectUri": "https://addon-host.com/hello-world",
+    {
+      "key": "clientSecret",
+      "text": {
+        "en": "Enter client key"
+      },
+      "type": "string",
+      "required": true,
+      "urlInclude": false
     }
+  ]
 }
 ```
 
@@ -124,7 +153,7 @@ manifest.host.url = "http://somesite.com/something"
 manifest.context = ["opp.id", "usr.id"]
 ```
 
-In the case of outreach user with id 456 looking at opportunity 123, this will result during the runtime.
+In the case of Outreach user with id 456 looking at opportunity 123, this will result during the runtime.
 
 ```bash
  http://somesite.com/something?opp.id=123&usr.id=456
@@ -164,7 +193,6 @@ http://somesite.com/something/456?oid=123
 
 base64 string represents the icon to be shown in the addon store and (if possible) in Outreach client.
 
-
 ### author
 
 This section contains information to be presented to a user of the addon in the marketplace and on the consent screen: addon creator name, website URL, privacy policy document URL, and terms of use document URL.
@@ -178,15 +206,24 @@ It is a string array of predefined Outreach properties describing attributes of 
 
 e.g. ["opp.id", "acc.id"]
 
-A complete list of all of the supported context properties can be found on the [context property page](context.md).
+Outreach User will be asked to consent to share this information before the addon is installed from the addon store.
+In case addon is installed by admin for other users, admin is the one consenting to share the defined context properties for all the org users he is installing it for.
 
-Outreach User will be asked to consent to share this information on the addon's first use.  If the manifest addon creator's future version adds additional contextual fields, the Outreach user will consent again.
+To learn more about the list of all of the supported context properties, go to [context property page](context.md).
 
-[ADD-CONTEXT-CONSENT-SCREENSHOT-HERE]
+## configuration
+
+This section is optional.
+If the addon doesn't need a user-specific runtime configuration, this section can be omitted.
+
+In this section, the addon creator defines what information should collect from the user and pass it to the addon as a part of the initialization process.
+
+To learn more about configuration section, go to [manifest configuration page](configuration.md)
 
 ## api (optional)
 
-This section is optional - if addon doesn't need access to outreach API, this section can be omitted.
+This section is optional.
+If the addon doesn't need access to outreach API, this section can be omitted.
 
 ### applicationId
 
@@ -202,7 +239,7 @@ In the scopes section, the addon creator defines Outreach API scopes that are ne
 
 A complete list of all of the API scopes can be found on [API Scopes page](scopes.md).
 
-On the first [SDK authentication](sdk.md#authentication) Outreach user is asked to consent with granting requested scopes to the addon
+On the first [SDK authentication](sdk.md#authentication) Outreach, the user is asked to consent to grant requested scopes to the addon
 ![alt text](assets/api-consent.png "API consent screen")
 
 ### token

--- a/docs/url-parsing.md
+++ b/docs/url-parsing.md
@@ -4,6 +4,7 @@ Any time when the Outreach app loads an addon, it will set as iframe source an U
 
 - host.URL value [defined in the manifest](manifest.md#url)
 - query parameters representing [context values of current Outreach user](manifest.md#context) also defined in the manifest (e.g. "opp.id")
+- [config parameters](configuration.md) (if any) which have [urlInclude](configuration.md##urlinclude) property enabled.
 - query params which are always sent regardless of the manifest:
   - locale='en',
   - theme='light'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/context/OutreachContext.ts
+++ b/src/context/OutreachContext.ts
@@ -5,6 +5,7 @@ import { AccountContext } from './AccountContext'
 import { Theme } from '../sdk/Theme'
 import { Locale } from '../sdk/Locale'
 import { ProspectContext } from './ProspectContext'
+import { ConfigurationValue } from '../store/configuration/ConfigurationValue'
 
 export class OutreachContext {
     /**
@@ -62,4 +63,13 @@ export class OutreachContext {
      * @memberof OutreachContext
      */
     public prospect?: ProspectContext;
+
+    /**
+     * Optional section containing configuration values
+    * provided by user.
+     *
+     * @type {ConfigurationValue[]}
+     * @memberof OutreachContext
+     */
+    public config?: ConfigurationValue[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,7 +247,7 @@ class AddonsSdk {
    * and then by asking addon host if it can produce a new access token from its own cache
    * or by using previously obtained refresh token.
    *
-   * @see https://github.com/getoutreach/clientxtsdk/blob/develop/docs/outreach-api.md#token-endpoint
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/outreach-api.md#token-endpoint
    *
    * @memberof AddonsSdk
    */

--- a/src/messages/InitMessage.ts
+++ b/src/messages/InitMessage.ts
@@ -6,6 +6,8 @@ import { Theme } from '../sdk/Theme';
 import { Locale } from '../sdk/Locale';
 import { ContextParam } from '../context/ContextParam';
 import { Manifest } from '../store/Manifest';
+import { ConfigurationItem } from '../store/configuration/ConfigurationItem';
+import { ConfigurationValue } from '../store/configuration/ConfigurationValue';
 
 export class InitMessage extends AddonMessage implements OutreachContext {
   /**
@@ -53,4 +55,13 @@ export class InitMessage extends AddonMessage implements OutreachContext {
    * @memberof InitMessage
    */
   manifest: Manifest;
+
+  /**
+   * Optional section containing configuration values
+   * provided by user.
+   *
+   * @type {ConfigurationItem[]}
+   * @memberof InitMessage
+   */
+  configuration?: ConfigurationValue[];
 }

--- a/src/sdk/Constants.ts
+++ b/src/sdk/Constants.ts
@@ -3,7 +3,7 @@ export class Constants {
    * Name of the local storage setting storing last retrieved access token information
    * which host uses to implement refresh token flow.
    *
-   * @see https://github.com/getoutreach/clientxtsdk/blob/develop/docs/outrach-api.md#caching-the-tokens
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/outrach-api.md#caching-the-tokens
    * @static
    * @memberof Constants
    */
@@ -16,7 +16,7 @@ export class Constants {
    * can correlate and cache retrieved token information with
    * a given user identifier.
    *
-   * @see https://github.com/getoutreach/clientxtsdk/blob/develop/docs/outreach-api.md#token-endpoint
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/outreach-api.md#token-endpoint
    *
    * @static
    * @memberof Constants

--- a/src/store/AddonStore.ts
+++ b/src/store/AddonStore.ts
@@ -1,4 +1,12 @@
 /* eslint-disable no-unused-vars */
+/**
+ *
+ * List of supported addon stores.
+ *
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#store
+ * @export
+ * @enum {number}
+ */
 export enum AddonStore {
   Personal = 'personal',
   Private = 'private',

--- a/src/store/AddonType.ts
+++ b/src/store/AddonType.ts
@@ -1,4 +1,10 @@
 /* eslint-disable no-unused-vars */
+/**
+ * List of supported addon types.
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#type
+ * @export
+ * @enum {number}
+ */
 export enum AddonType {
   AccountTab = 'tab-account',
   OpportunityTab = 'tab-opportunity',

--- a/src/store/LocalizedString.ts
+++ b/src/store/LocalizedString.ts
@@ -1,3 +1,3 @@
 export class LocalizedString {
-  public en: string = 'en';
+  public en: string;
 }

--- a/src/store/Manifest.ts
+++ b/src/store/Manifest.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { AddonStore } from './AddonStore';
+import { ConfigurationItem } from './configuration/ConfigurationItem';
 import { AllContextKeys } from './keys/AllContextKeys';
 import { LocalizedString } from './LocalizedString';
 import { ManifestApi } from './ManifestApi';
@@ -10,7 +11,7 @@ import { ManifestHost } from './ManifestHost';
  * Definition of the manifest file containing all the information
  * needed for Outreach platform addon.
  *
- * @see https://github.com/getoutreach/clientxtsdk#manifest-file
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#manifest-file
  *
  * @export
  * @class Manifest
@@ -22,7 +23,8 @@ export class Manifest {
    * In case addon doesn't need client access to Outreach API
    * this secrion can be ommited from configuration.
    *
-   * @see https://github.com/getoutreach/clientxtsdk#api-optional
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#api-optional
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/outreach-api.md
    * @type {ManifestApi}
    * @memberof Manifest
    */
@@ -32,7 +34,7 @@ export class Manifest {
    * This section contains information to be presented to a user of the addon in the marketplace and on the
    * consent screen: addon creator name, website URL, privacy policy document URL, and terms of use document URL.
    *
-   * @see https://github.com/getoutreach/clientxtsdk#author
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#author
    * @type {ManifestAuthor}
    * @memberof Manifest
    */
@@ -43,17 +45,35 @@ export class Manifest {
    * to be sent during the initialization process.
    * It is a string array of predefined Outreach properties describing attributes of the Outreach user loading the addon.
    *
-   * @see https://github.com/getoutreach/clientxtsdk#identifier
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#context
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/context.md
    * @type {AllContextKeys[]}
    * @memberof Manifest
    */
   public context: AllContextKeys[];
 
   /**
+   * An optional section containing configuration information
+   * describing what values user needs to provide when interacting
+   * for the first time with addon (loading or installing)
+   *
+   * All of the configuration values will be sent to Addon using the
+   * initialization iframe POST message.
+   *
+   * All of the *public* configuration items will be sent to Addon
+   * as the query paramters and can be parsed as such.
+   *
+   *   *
+   * @type {ConfigurationItem[]}
+   * @memberof Manifest
+   */
+  public configuration?: ConfigurationItem[];
+
+  /**
    * A localized addon description is shown in the addon store to
    * explain what the addon does and why someone would want to install it.
    *
-   * @see https://github.com/getoutreach/clientxtsdk#description
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#description
    * @type {LocalizedString}
    * @memberof Manifest
    */
@@ -62,7 +82,7 @@ export class Manifest {
   /**
    * Definition of addon host
    *
-   * @see https://github.com/getoutreach/clientxtsdk#host
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#host
    * @type {ManifestHost}
    * @memberof Manifest
    */
@@ -71,7 +91,7 @@ export class Manifest {
   /**
    * Unique identifier of the addon
    *
-   * @see https://github.com/getoutreach/clientxtsdk#identifier
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#identifier
    * @type {string}
    * @memberof Manifest
    */
@@ -80,7 +100,7 @@ export class Manifest {
   /**
    * The localized addon title is shown in the addon store and Outreach app as a tab tile.
    *
-   * @see https://github.com/getoutreach/clientxtsdk#title
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#title
    * @type {LocalizedString}
    * @memberof Manifest
    */
@@ -88,8 +108,8 @@ export class Manifest {
 
   /**
    * Type of addon: public, private or personal.
-   * @see https://github.com/getoutreach/clientxtsdk#store
    *
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#store
    * @type {AddonStore}
    * @memberof Manifest
    */
@@ -98,6 +118,7 @@ export class Manifest {
   /**
    * Manifest version
    *
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#version
    * @type {string}
    * @memberof Manifest
    */

--- a/src/store/ManifestApi.ts
+++ b/src/store/ManifestApi.ts
@@ -1,11 +1,18 @@
 // eslint-disable-next-line no-unused-vars
 import { Scopes } from './Scopes';
 
+/**
+ * Optional section defining parameters needed for accessing Outreach API.
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#api-optional
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/outreach-api.md
+ * @export
+ * @class ManifestApi
+ */
 export class ManifestApi {
     /**
      * Outreach OAuth application id
      *
-     * @see https://github.com/getoutreach/clientxtsdk/blob/develop/docs/outreach-oauth-settings.md
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#applicationid
      * @type {string}
      * @memberof ManifestApi
      */
@@ -14,8 +21,7 @@ export class ManifestApi {
     /**
      * Outreach OAuth App redirect uri on which the Authorization endpoint is implemented.
      *
-     * @see https://github.com/getoutreach/clientxtsdk/blob/develop/docs/outreach-oauth-settings.md
-     * @see https://github.com/getoutreach/clientxtsdk/tree/develop/docs/outreach-api.md#authorization-endpoint
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#redirecturi
      * @type {string}
      * @memberof ManifestApi
      */
@@ -26,7 +32,7 @@ export class ManifestApi {
      * where current Outreach user will be asked to consent for granting
      * permissions for defined scopes to addon creator.
      *
-     * @see https://github.com/getoutreach/clientxtsdk#scopes
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#scopes
      * @type {Scopes[]}
      * @memberof Api
      */
@@ -35,7 +41,7 @@ export class ManifestApi {
     /**
      * Address of the endpoint, which will return support refresh token flow.
      *
-     * @see https://github.com/getoutreach/clientxtsdk/tree/develop/docs/outreach-api.md#token-endpoint
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#token
      * @type {string}
      * @memberof Api
      */
@@ -47,7 +53,7 @@ export class ManifestApi {
      * posting authentication token info back to addon page which
      * had opened the popup.
      *
-     * @see https://github.com/getoutreach/clientxtsdk/tree/develop/docs/outreach-api.md#connect-endpoint
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#token
      * @type {string}
      * @memberof Api
      */

--- a/src/store/ManifestAuthor.ts
+++ b/src/store/ManifestAuthor.ts
@@ -1,7 +1,14 @@
 
+/**
+ * Section of the manifest describing the addon author.
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#author
+ * @export
+ * @class ManifestAuthor
+ */
 export class ManifestAuthor {
     /**
      *
+     * Website of the addon creator.
      *
      * @type {string}
      * @memberof Author
@@ -9,7 +16,7 @@ export class ManifestAuthor {
     websiteUrl: string;
 
     /**
-     *
+     * Url of the addon creator privacy policy.
      *
      * @type {string}
      * @memberof Author
@@ -17,16 +24,10 @@ export class ManifestAuthor {
     privacyUrl: string;
 
     /**
-     *
+     * Terms of use policy url.
      *
      * @type {string}
      * @memberof Author
      */
     termsOfUseUrl: string;
-
-    constructor () {
-      this.websiteUrl = '';
-      this.privacyUrl = '';
-      this.termsOfUseUrl = '';
-    }
 }

--- a/src/store/ManifestHost.ts
+++ b/src/store/ManifestHost.ts
@@ -1,10 +1,17 @@
 // eslint-disable-next-line no-unused-vars
 import { AddonType } from './AddonType';
 
+/**
+ * Section defining the addon creator hosting property.
+ *
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#host
+ * @export
+ * @class ManifestHost
+ */
 export class ManifestHost {
     /**
      * Type property defines what the type of addon is and where it should be loaded.
-     * @see https://github.com/getoutreach/clientxtsdk#type-host
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#type
      * @type {AddonType}
      * @memberof Host
      */
@@ -13,7 +20,7 @@ export class ManifestHost {
     /**
      * Address where the addon hosting web page is hosted.
      *
-     * @see https://github.com/getoutreach/clientxtsdk#url
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#url
      * @type {string}
      * @memberof Host
      */
@@ -23,7 +30,7 @@ export class ManifestHost {
      * Base64 string represents the icon to be shown in the addon store
      * and (if applicable) in the Outreach app.
      *
-     * @see https://github.com/getoutreach/clientxtsdk#icon
+     * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#icon
      * @type {string}
      * @memberof Host
      */

--- a/src/store/Scopes.ts
+++ b/src/store/Scopes.ts
@@ -1,5 +1,12 @@
 /* eslint-disable no-unused-vars */
 
+/**
+ * List of Outreach API scopes addon can request
+ *
+ * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/scopes.md
+ * @export
+ * @enum {number}
+ */
 export enum Scopes {
     AUDITS_ALL = 'audits.all',
     AUDITS_READ = 'audits.read',

--- a/src/store/configuration/ConfigurationItem.ts
+++ b/src/store/configuration/ConfigurationItem.ts
@@ -1,0 +1,80 @@
+import { LocalizedString } from '../LocalizedString';
+import { ConfigurationItemOption } from './ConfigurationItemOption';
+import { ConfigurationItemType } from './ConfigurationItemType';
+
+export class ConfigurationItem {
+  /**
+   * Keycode of the configuration value.
+   * It is sent as a part of the addon initialization context, and through the URL,
+   * so it is recommended to be short
+   *
+   * @type {string}
+   * @memberof ManifestConfigurationItem
+   */
+  public key: string;
+
+  /**
+   * Localized text of the label text is shown to a user explaining
+   * the configuration value the user needs to provide.
+   *
+   * @type {LocalizedString}
+   * @memberof ManifestConfigurationItem
+   */
+  public text: LocalizedString;
+
+  /**
+   *
+   * Type of the configuration value data.
+   * This has impact on rendering UI input components.
+   *
+   * "options" - multiselect control producing an array of option values
+   * "select" - single select control selecting one of the possible config values
+   *
+   * @type {ConfigurationItemType}
+   * @memberof ManifestConfigurationItem
+   */
+  public type: ConfigurationItemType = 'string';
+
+  /**
+   * Define if the config value is mandatory and has to be provided by the user.
+   *
+   * @type {boolean}
+   * @memberof ManifestConfigurationItem
+   */
+  public required: boolean = true;
+
+  /**
+   * An optional regex expression which will be used to validate
+   * the configuration value entered by user.
+   *
+   * @type {string}
+   * @memberof ManifestConfigurationItem
+   */
+  public validator?: string;
+
+  /**
+   * An optional default value to be offered to user
+   * by default when the configuration component loads
+   *
+   * @type {string}
+   * @memberof ConfigurationItem
+   */
+  public defaultValue?: string;
+
+  /**
+   * An optional collection of values is presented to the user
+   * if the type is 'options' or 'select' from which the user selects one or more options.
+   *
+   * @type {ConfigurationItemOption[]}
+   * @memberof ConfigurationItem
+   */
+  public options?: ConfigurationItemOption[];
+
+  /**
+   * A value defining if configuration value can be passed through the url or not.
+   *
+   * @type {boolean}
+   * @memberof ConfigurationItem
+   */
+  public urlInclude: boolean = false;
+}

--- a/src/store/configuration/ConfigurationItemOption.ts
+++ b/src/store/configuration/ConfigurationItemOption.ts
@@ -1,0 +1,21 @@
+import { LocalizedString } from '../LocalizedString';
+
+export class ConfigurationItemOption {
+  /**
+   * A value which will be used as user entry
+   * if this option is selected
+   *
+   * @type {string}
+   * @memberof Option
+   */
+  value: string;
+
+  /**
+   * Localized text of the option shown to a user
+   * so the user can pick the right config value.
+   *
+   * @type {LocalizedString}
+   * @memberof Option
+   */
+  text: LocalizedString;
+}

--- a/src/store/configuration/ConfigurationItemType.ts
+++ b/src/store/configuration/ConfigurationItemType.ts
@@ -1,0 +1,1 @@
+export declare type ConfigurationItemType = 'string' | 'number' | 'date' | 'uri' | 'options' | 'select'

--- a/src/store/configuration/ConfigurationValue.ts
+++ b/src/store/configuration/ConfigurationValue.ts
@@ -1,0 +1,24 @@
+/**
+ * Configuration value entered by user
+ *
+ * @export
+ * @class ConfigurationValue
+ */
+export class ConfigurationValue {
+  /**
+   *
+   * Configuration item key
+   *
+   * @type {string}
+   * @memberof ConfigurationValue
+   */
+  public key: string;
+  /**
+   *
+   * Configuration item value user provided
+   *
+   * @type {string}
+   * @memberof ConfigurationValue
+   */
+  public value: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,7 +113,7 @@ export class utils {
     }
 
     // connect endpoint is posting a message with token to addon so it is valid origin
-    // see: https://github.com/getoutreach/clientxtsdk/blob/develop/docs/outreach-api.md#connect-endpoint
+    // see: https://github.com/getoutreach/clientxtsdk/blob/master/docs/outreach-api.md#connect-endpoint
     const connectUri = new URL(runtime.manifest.api.connect);
     const connectOrigin = utils.getUrlDomain(connectUri);
     const connectMessage = origin === connectOrigin;


### PR DESCRIPTION
Every addon creator can define in the manifest file Configuration section containing the metadata describing the information user needs to provide upon the install/initial loading of the addon.