### PR TITLE
XT-144 SDK initialization rewrite

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -5,10 +5,9 @@ Table of content
 
 - [Summary](#summary)
 - [Addon initialization](#addon-initialization)
-  - [Init event handler](#init-event-handler)
-    - [Outreach context](#outreach-context)
   - [Info event handler (optional)](#info-event-handler-optional)
-  - [Ready function](#ready-function)
+  - [Sdk initialization](#sdk-initialization)
+    - [Outreach context](#outreach-context)
 - [Additional addon functions](#additional-addon-functions)
   - [Notify function](#notify-function)
   - [Decorate function](#decorate-function)
@@ -34,36 +33,8 @@ In case you don't want to use the NPM package, we are also publishing it as a ja
 
 In order for the addon to get into initialized state, there are a few simple steps to be performed on the addon host page:
 
-- Subscribe to an [initialization event](#init-event-handler)
-- Subscribe to [info event](#info-event-handler-optional)(optional)
-- Invoke a [READY function](#ready-function).
-
-### Init event handler
-
-The Outreach host sends to addon contextual information of the current Outreach user loading the addon, which triggers on addon side init event handler. In case the initialization context changes after the addon are loaded, another Init message will be sent to the addon so it can reinitialize itself with the new context.
-
-The manifest Context section determines the payload of the initialization context (e.g., if there is Opportunity scope defined, the initialization context will contain current opportunity information).
-
-```javascript
-addonSdk.onInit = (ctx: OutreachContext) => {
-    // addon initialization based on this values
-}
-```
-
-This event handler is invoked once on initial addon loading and every time after that when the initialization context
-of Outreach context changes.
-
-#### Outreach context
-
-[Outreach context](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/OutreachContext.ts) sent to onInit method has next properties:
-
-- locale - Outreach User locale to be used for rendering addon UI (e.g. en)
-- theme - Outreach app theme to be used for rendering addon UI (e.g. light)
-- account - [Information about current account](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/AccountContext.ts) Outreach user is looking at (optional)
-- user - [Information about current outreach user](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/UserContext.ts) Outreach user is looking at (optional)
-- opportunity - [Information about current opportunity](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/OpportunityContext.ts) Outreach user is looking at (optional)
-- prospect - [Information about current prospect](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/ProspectContext.ts) Outreach user is looking at (optional)
-- config - User-specific [addon configuration](configuration.md#) (if any)
+- Subscribe to [info event](#info-event-handler-optional) (optional)
+- Sdk [initialization](#sdk-initialization).
 
 ### Info event handler (optional)
 
@@ -82,15 +53,35 @@ None| Debug  | Info | Warn | Error.
 addonSdk.logLevel = LogLevel.Debug;
 ```
 
-### Ready function
+### Sdk initialization
 
-Once all the handlers are defined, and as soon as possible, addon sends a message to the host that it is ready for initialization by directly calling the ready method.
+The Outreach host sends to addon contextual information of the current Outreach user loading the addon, which triggers on addon side init event handler.
+
+The manifest Context section determines the payload of the initialization context (e.g., if there is an Opportunity scope defined, the initialization context will contain current opportunity information).
+
+To retrieve the Outreach initialization context, sdk needs to initialize
 
 ```javascript
-addonSdk.ready();
+// ctx: OutreachContext
+  const ctx = await addonSdk.init(); 
+
 ```
 
 This will result in an iframe post message being sent to the host informing the Outreach app that the addon is ready to receive initialization context describing the current Outreach user loading the addon.
+
+Once the initialization context is received, sdk is ready to perform its functionality.
+
+#### Outreach context
+
+[Outreach context](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/OutreachContext.ts) sent to onInit method has next properties:
+
+- locale - Outreach User locale to be used for rendering addon UI (e.g. en)
+- theme - Outreach app theme to be used for rendering addon UI (e.g. light)
+- account - [Information about current account](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/AccountContext.ts) Outreach user is looking at (optional)
+- user - [Information about current outreach user](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/UserContext.ts) Outreach user is looking at (optional)
+- opportunity - [Information about current opportunity](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/OpportunityContext.ts) Outreach user is looking at (optional)
+- prospect - [Information about current prospect](https://github.com/getoutreach/clientxtsdk/blob/master/src/context/ProspectContext.ts) Outreach user is looking at (optional)
+- config - User-specific [addon configuration](configuration.md#) (if any)
 
 ## Additional addon functions
 
@@ -122,7 +113,7 @@ To support addons needing Outreach API access, addon SDK implements two actions:
 
 [source here](https://github.com/getoutreach/clientxtsdk/blob/master/src/index.ts#L254)
 
-This function addon calls anytime it needs a token to access Outreach API - no need to tie it to any user generated action (e.g. button click) as there are no popups
+This function addon calls anytime it needs a token to access Outreach API - no need to tie it to any user-generated action (e.g., button click) as there are no popups.
 
 ```javascript
     addonSdk.getToken = (skipCache?: bool) => Promise<string> {
@@ -132,13 +123,13 @@ This function addon calls anytime it needs a token to access Outreach API - no n
 
 This function will:
 
-- check if local storage has item with key **cxt-sdk-token**
+- check if local storage has an item with key **cxt-sdk-token**
 - it will check if the cached access token didn't expire
-- if cached token is still active the promise will resolve and addon creator will get a token.
+- if the cached token is still active, the promise will resolve, and the addon creator will get a token.
 
 Suppose a valid access token is not in the local storage.
 
-In that case, function will call the [token endpoint](outreach-api.md#token-endpoint) and try to obtain new access token, cache it to local storage and return it to user resolving the promise.
+In that case, the function will call the [token endpoint](outreach-api.md#token-endpoint) and try to obtain a new access token, cache it to local storage and return it to the user resolving the promise.
 
 ### authorize function
 
@@ -150,8 +141,8 @@ In that case, function will call the [token endpoint](outreach-api.md#token-endp
     }
 ```
 
-If a sdk.getToken() function fails, addon creator has to show some clickable element ("Login button"). Once a user clicks that button, a [Outreach OAuth consent popup](outreach-api.md#outreach-api-consent) will be shown to user and a [authorize endpoint](outreach-api.md##authorization-endpoint) will be called. Authorize flow will [cache on server refresh token](outreach-api.md#caching-the-tokens) and on client local storage access token so future getToken() calls will work and there won't be no need to show popup to user again.
+If a sdk.getToken() function fails, addon creator has to show some clickable element ("Login button"). Once a user clicks that button, a [Outreach OAuth consent popup](outreach-api.md#outreach-api-consent) will be shown to user and a [authorize endpoint](outreach-api.md##authorization-endpoint) will be called. Authorize flow will [cache on server refresh token](outreach-api.md#caching-the-tokens) and on client local storage access token so future getToken() calls will work and there won't be any need to show popup to the user again.
 
-In case addon creator will call authorize() function after user provided content, Outreach user will briefly see a popup being loaded and immediately closed after a very breif period.
+In case of an addon, the creator will call authorize() function after user-provided content. Outreach users will briefly see a popup being loaded and immediately closed after a very brief period.
 
-An important implementation detail of this function is that before a popup is shown, sdk will create a cookie called "ctx-sdk-token" where user identifier will be stored so the addon host can read that value later for [caching tokens](outreach-api.md#caching-the-tokens) implementation.
+An important implementation detail of this function is that before a popup is shown, sdk will create a cookie called "ctx-sdk-token" where the user identifier will be stored so the addon host can read that value later for [caching tokens](outreach-api.md#caching-the-tokens) implementation.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.0.124",
+  "version": "0.10",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ class AddonsSdk {
    * Init handler being invoked when addon initialized is completed
    * and addon receives from the Outreach host initialization context 
    * 
-   * @deprecated Since version 0.10. Use instead await sdk.init()
+   * @deprecated Since version 0.10. Will be removed in version 1.0. Use instead await sdk.init()
    *
    * @memberof AddonsSdk
    */
@@ -133,7 +133,7 @@ class AddonsSdk {
    * ready to receive messages from host and other participants.
    *
    * @memberof AddonsSdk
-   * @deprecated Since version 0.10. Use instead await sdk.init()
+   * @deprecated Since version 0.10. Will be removed in version 1.0. Use instead await sdk.init()
    */
   public ready () {
     console.warn("Ready function is depricated. Use instead await sdk.init()");

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,11 +77,23 @@ class Task<T> {
 }
 
 class AddonsSdk {
+
+  private initTimer?: number;
+  private initTask?: Task<OutreachContext>;
+  
   private authorizeTask: Task<string | null>;
 
   public getRuntime = (): RuntimeContext => runtime;
   public activeListener: boolean = false;
 
+  /**
+   * Init handler being invoked when addon initialized is completed
+   * and addon receives from the Outreach host initialization context 
+   * 
+   * @deprecated Since version 0.10. Use instead await sdk.init()
+   *
+   * @memberof AddonsSdk
+   */
   public onInit: (context: OutreachContext) => void;
 
   public onMessage: (message: AddonMessage) => void;
@@ -121,8 +133,11 @@ class AddonsSdk {
    * ready to receive messages from host and other participants.
    *
    * @memberof AddonsSdk
+   * @deprecated Since version 0.10. Use instead await sdk.init()
    */
   public ready () {
+    console.warn("Ready function is depricated. Use instead await sdk.init()");
+
     if (!this.activeListener) {
       this.activeListener = true;
       window.addEventListener('message', this.handleReceivedMessage);
@@ -158,7 +173,10 @@ class AddonsSdk {
    *
    * @memberof AddonsSdk
    */
-  public notify = (text: string, type: NotificationType) => {
+  public notify = async (text: string, type: NotificationType) => {
+
+    await this.verifySdkInitialized();
+
     const message = new NotificationMessage();
     message.notificationText = text;
     message.notificationType = type;
@@ -180,7 +198,10 @@ class AddonsSdk {
    *
    * @memberof AddonsSdk
    */
-  public decorate = (text: string) => {
+  public decorate = async (text: string) => {
+
+    await this.verifySdkInitialized();
+    
     const message = new DecorationMessage();
     message.decorationText = text;
     this.sendMessage(message, true);
@@ -200,7 +221,10 @@ class AddonsSdk {
    *
    * @memberof AddonsSdk
    */
-  public configure = () => {
+  public configure = async () => {
+
+    await this.verifySdkInitialized();
+
     const message = new ConfigureMessage();
     this.sendMessage(message, true);
 
@@ -214,6 +238,38 @@ class AddonsSdk {
     });
   };
 
+
+  /**
+   * Initialize the SDK by sending a ready() signal to the Outreach host
+   * and resolving a promise when Outreach host responds with a current user
+   * initialization context
+   *
+   * @returns {Promise<OutreachContext>}
+   * @memberof AddonsSdk
+   */
+  public init = async (): Promise<OutreachContext> => {
+    if (this.initTask) {
+      return this.initTask.promise;
+    }
+
+    this.initTask = new Task<OutreachContext>();
+    this.initTask.promise =  new Promise<OutreachContext>((resolve, reject) => {
+      this.initTask!.onfulfilled = resolve;
+      this.initTask!.onrejected = reject;
+
+      this.ready();
+
+      this.initTimer = window.setTimeout(() => {
+        const error = "[CTX] Addon initialization failed - timeout error";
+        console.error(error);
+        reject(error);
+      }, 10 * 1000);
+    });
+
+    return this.initTask.promise;
+  }
+
+
   /**
    *
    * Initialize the OAuth consent process by presenting to Outreach user
@@ -226,9 +282,13 @@ class AddonsSdk {
    * it has to be invoked in a handler of the direct user action
    * (e.g. user clicked a button)
    *
+   * @returns {Promise<string | null>}
    * @memberof AddonsSdk
    */
-  public authenticate = (): Promise<string | null> => {
+  public authenticate = async (): Promise<string | null> => {
+
+    await this.verifySdkInitialized();
+
     this.authorizeTask = new Task<string | null>();
     this.authorizeTask.promise = new Promise<string | null>(
       (resolve, reject) => {
@@ -272,6 +332,9 @@ class AddonsSdk {
    * @memberof AddonsSdk
    */
   public getToken = async (skipCache?: boolean): Promise<string | null> => {
+    
+    await this.verifySdkInitialized();
+
     if (!skipCache) {
       const cachedToken = await tokenService.getCachedTokenAsync();
       if (cachedToken) {
@@ -306,6 +369,28 @@ class AddonsSdk {
     window.parent.postMessage(postMessage, runtime.origin);
   }
 
+  private verifySdkInitialized = async () => {
+    
+    // check if sdk.init() was called
+    if (!this.initTask) {
+      const error = "[CXT] Please initialize SDK by calling sdk.init() before performing any additional calls";
+      this.logger.log({
+        origin: EventOrigin.ADDON,
+        type: EventType.INTERNAL,
+        messageType: AddonMessageType.INIT,
+        level: LogLevel.Error,
+        message: error,
+        context: [ runtime.origin]
+      });
+      
+      // throw an error - case is THAT important
+      throw new Error(error);
+    }
+      
+    // check if sdk.init() was resolved
+    await this.initTask
+  }
+
   private handleReceivedMessage = (messageEvent: MessageEvent) => {
     const addonMessage = this.getAddonMessage(messageEvent);
     if (!addonMessage) {
@@ -333,6 +418,7 @@ class AddonsSdk {
       case AddonMessageType.INIT: {
         const context = addonMessage as InitMessage;
         this.preprocessInitMessage(context);
+        this.resolveInitPromise(context);
         this.onInit(context);
         break;
       }
@@ -361,6 +447,13 @@ class AddonsSdk {
         });
     }
   };
+
+  private resolveInitPromise = (ctx: OutreachContext) => {
+    window.clearTimeout(this.initTimer);
+    if (this.initTask) {
+      this.initTask.onfulfilled(ctx)
+    }
+  }
 
   private preprocessInitMessage = (initMessage: InitMessage) => {
     runtime.locale = initMessage.locale;
@@ -416,7 +509,6 @@ class AddonsSdk {
       ]
     });
 
-    this.onInit(outreachContext);
   };
 
   private handleRefreshTokenMessage = (tokenMessage: ConnectTokenMessage) => {


### PR DESCRIPTION
We are switching from 

```
sdk.onInit = ctx => ...
sdk.ready()

```
to 
`
const ctx = await sdk.init()
`