### PR TITLE
Build cookie name using specified name instead of domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,7 @@ class AddonsSdk {
         // start the OAuth consent flow by recording user identifier
         // addon host server will need server will need
         // to read in its OAuth implementation
-        const cookieContent = `${this.cookie.domain}=${
+        const cookieContent = `${this.cookie.name}=${
           runtime.userIdentifier
         };Secure;SameSite=None;Path=/;Domain=${
           this.cookie.domain


### PR DESCRIPTION
Quick bugfix, the cookie being built was using the domain instead of the specified name.

Not sure if I'm following the right process for PRs but figured I'd save the team some work.
