### PR TITLE
fix: add json schema to validate manifest [OREX-54]

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -52,7 +52,7 @@ Here is the sample manifest file of the hello world addon
     "fr": "Salut tout le monde"
   },
   "description": {
-    "en": "This is a sample addon created as a guide for Outreach addon creators,",
+    "en": "This is a sample addon created as a guide for Outreach addon creators",
     "fr": "Il s’agit d’un addon échantillon créé comme un guide pour les créateurs addon Outreach"
   },
   "host": {
@@ -60,8 +60,8 @@ Here is the sample manifest file of the hello world addon
     "url": "https://addon-host.com/something",
     "icon": "https://addon-host.com/icon.png",
     "environment": {
-      "fullWidth": "true",
-      "decoration": "simple" 
+      "fullWidth": true,
+      "decoration": "simple"
     }
   },
   "author": {
@@ -70,14 +70,14 @@ Here is the sample manifest file of the hello world addon
     "termsOfUseUrl": "https://addon-host.com/tos"
   },
   "context": [
-    "usr.id", 
-    "opp.id", 
+    "usr.id",
+    "opp.id",
     "pro.id"
   ],
   "api": {
     "token": "https://addon-host.com/token",
     "scopes": [
-      "prospects.read", 
+      "prospects.read",
       "opportunities.read"
     ],
     "applicationId": "AbCd123456qW",
@@ -85,12 +85,12 @@ Here is the sample manifest file of the hello world addon
     "connect": "https://addon-host.com/connect"
   },
   "configuration": [{
-      "key": "project", "type": "string", 
+      "key": "project", "type": "string",
       "required": true, "urlInclude": true,
       "text": {
         "en": "Project name."
       }
-  }],
+  }]
 }
 ```
 
@@ -106,6 +106,10 @@ Here is the sample manifest file of the hello world addon
 ### identifier
 
 Unique identifier of the addon as defined by the addon creator
+
+### version
+
+A version of addon manifest in the format MAJOR.MINOR
 
 ### store
 

--- a/docs/schema/1.0/manifest.schema.json
+++ b/docs/schema/1.0/manifest.schema.json
@@ -1,0 +1,164 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/getoutreach/clientxtsdk/docs/schema/1.0/manifest.schema.json",
+    "properties": {
+        "version": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+$",
+            "maxLength": 64
+        },
+        "identifier": {
+            "type": "string",
+            "maxLength": 128
+        },
+        "store": {
+            "type": "string",
+            "enum": [
+                "private",
+                "public",
+                "personal"
+            ]
+        },
+        "title": {
+            "type": "object",
+            "properties": {
+                "en": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "en"
+            ]
+        },
+        "description": {
+            "type": "object",
+            "properties": {
+                "en": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "en"
+            ]
+        },
+        "host": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "tab-account",
+                        "tab-opportunity",
+                        "tab-prospect",
+                        "left-side-menu"
+                    ]
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "environment": {
+                    "type": "object",
+                    "properties": {
+                        "fullWidth": {
+                            "type": "boolean"
+                        },
+                        "decoration": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "author": {
+            "type": "object",
+            "properties": {
+                "websiteUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "privacyUrl": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "termsOfUseUrl": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "required": ["websiteUrl"]
+        },
+        "context": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "api": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "applicationId": {
+                    "type": "string"
+                },
+                "redirectUri": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "connect": {
+                    "type": "string"
+                }
+            }
+        },
+        "configuration": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "required": {
+                        "type": "boolean"
+                    },
+                    "urlInclude": {
+                        "type": "boolean",
+                        "format": "uri"
+                    },
+                    "text": {
+                        "type": "object",
+                        "properties": {
+                            "en": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "version",
+        "identifier",
+        "title",
+        "host",
+        "author"
+    ]
+}


### PR DESCRIPTION
I added manifest JSON schema, so it could be used by our customers and backend service to validate the correctness of addon-manifest JSON.

Also, we can rewrite our tests/ to use this schema.

Fixed minor bugs and typos in docs/manifest