### PR TITLE
ci: publish only if pkg version changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,16 @@
 version: 2.1
 
+commands:
+    check-version:
+        description: Halt Circle CI step if pkg version did not change
+        steps:
+            - run: |
+                version_diff=$(git diff main | grep \"version\": | wc -l || :)
+                if [[ $version_diff -eq 0 ]]; then
+                  echo "Halt due to no updated version"
+                  circleci step halt
+                fi
+
 jobs:
     test:
         working_directory: ~/repo
@@ -26,6 +37,7 @@ jobs:
             - image: circleci/node:latest
         steps:
             - checkout
+            - check-version
             - run:
                 name: Installing package dependencies
                 command: yarn install --frozen-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ commands:
         description: Halt Circle CI step if pkg version did not change
         steps:
             - run: |
-                version_diff=$(git diff main | grep \"version\": | wc -l || :)
+                version_diff=$(git diff main package.json | grep \"version\": | wc -l || :)
                 if [[ $version_diff -eq 0 ]]; then
                   echo "Halt due to no updated version"
                   circleci step halt


### PR DESCRIPTION
Adds command to `publish` step to check if package version changed. In case the version did not change the job stops gracefully.

Ticket: [OREX-217](https://outreach-io.atlassian.net/browse/OREX-217)