### PR TITLE
OREX-146 SDK support for prospect external context property

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -6,11 +6,15 @@ Table of content:
 - [Account contextual information](#account-contextual-information)
 - [Opportunity contextual information](#opportunity-contextual-information)
 - [Prospect contextual information](#prospect-contextual-information)
+  - [Prospect external information](#prospect-external-information)
+    - [External information payload](#external-information-payload)
+    - [Accessing external information from SDK](#accessing-external-information-from-sdk)
+    - [External information from URL](#external-information-from-url)
 - [User contextual information](#user-contextual-information)
 
 Every addon can request one or more contextual values describing the current Outreach user.
 
-The properties are grouped in for groups: account, opportunity, prospect and user.
+The properties are grouped into four groups: account, opportunity, prospect, and user.
 
 *In case you would like to have additional contextual properties, please contact us on **cxt-sdk@outreach.io.***
 
@@ -30,9 +34,9 @@ Our end goal is to provide contextual access to any of the properties available 
 
 ## Opportunity contextual information
 
-If an addon needs contextual information about the current opportunity Outreach user is looking at, it will need to add to manifest one or more opportunity properties.
+If an addon needs contextual information about the current opportunity the Outreach user is looking at, it will need to add to manifest one or more opportunity properties.
 
-Our end goal is to provide contextual access to any of the properties available through the [Outreach API](https://api.outreach.io/api/v2/docs#opportunity), but at the moment we support in [SDK](../src/store/keys/OpportunityContextKeys.ts) next properties:
+Our end goal is to provide contextual access to any of the properties available through the [Outreach API](https://api.outreach.io/api/v2/docs#opportunity), but at the moment, we support in [SDK](../src/store/keys/OpportunityContextKeys.ts) next properties:
 
 - **opp.amnt** The amount the opportunity is worth.
 - **opp.desc** A description of the opportunity.
@@ -49,7 +53,7 @@ Our end goal is to provide contextual access to any of the properties available 
 
 If an addon needs contextual information about the current prospect Outreach user is looking at, it will need to add to manifest one or more prospect properties.
 
-Our end goal is to provide contextual access to any of the properties available through the [Outreach API](https://api.outreach.io/api/v2/docs#prospect), but at the moment we support in [SDK](../src/store/keys/ProspectContextKeys.ts) next properties:
+Our end goal is to provide contextual access to any of the properties available through the [Outreach API](https://api.outreach.io/api/v2/docs#prospect), but at the moment, we support in [SDK](../src/store/keys/ProspectContextKeys.ts) next properties:
 
 - **pro.avail** The date and time the prospect is available to contact again.
 - **pro.comp** The name of the prospect company. If associated with an account, this is the name of the account. (e.g. Acme International).
@@ -57,20 +61,57 @@ Our end goal is to provide contextual access to any of the properties available 
 - **pro.loc** The locality of the prospect's company.
 - **pro.id** Prospect id
 - **pro.tags** A list of tag values associated with the account (e.g. ["Interested", "2017 Expo"]).
-- **pro.tzone** The prospect's current timezone, preferably in the IANA format (e.g. "America/LosAngeles").
+- **pro.tzone** The prospect's current timezone, preferably in the IANA format (e.g., "America/LosAngeles").
 - **pro.title** The title of the prospect.
 - **pro.csf1** to **pro.csf120** the value of the (1-120) prospect's custom field.
+
+### Prospect external information
+
+Every Outreach user can have one or more plugins installed and connect Outreach with Salesforce, Dynamics and other providers. We have a dedicated manifest key **pro.ext** to receive this external prospect information, which addon creators select in the manifest when addon needs to get this external prospect information.
+
+#### External information payload
+
+The value of this property is a complex object array, where each one of the array items represents information of one of the plugins. For example, if Outreach user has installed plugins for Salesforce and Dynamics, the array will have two objects with prospect information in each one of these external systems.
+This external information object has a few external contextual properties:
+
+- **enabled**   is plugin intergation enabled?
+- **id**   external prospect id  (e.g. 00Q090000030WR6EAM)
+- **name**  external prospect name
+- **type**  external prospect type (e.g. LEAD)
+- **provider**   1 - Salesforce, 2 - Salesforce (sandbox), 3 - Dynamics
+- **lastInbound**  Last date when the prospect data are synced to Outreach from external system
+- **lastOutbound** Last date when the prospect data are synced to the external system from Outreach
+
+#### Accessing external information from SDK
+
+This information is a standard part of the [initialization Outreach context](https://github.com/getoutreach/clientxtsdk/blob/main/docs/sdk.md#outreach-context) external info property
+
+ctx.prospect.externalInfo : [ExternalProspectContext](https://github.com/getoutreach/clientxtsdk/blob/main/src/context/ExternalProspectContext.ts)
+
+#### External information from URL
+
+To reduce the length of the URL, external information is packed to the shorter format by using the **pack()** function of [ExternalProspectUtils](https://github.com/getoutreach/clientxtsdk/blob/main/src/context/ExternalProspectUtils.ts).
+
+The value is JSON serialized form of the contextual array with all the property names being abbreviated. To read the values addon creator has to use either **unpack()** function from the ExternalProspectUtils or manually deserialize the array and read the values using abbreviated property names.
+
+- **enabled**   -> e
+- **id**   -> i
+- **name**  -> n
+- **type**  -> t
+- **provider**   -> p
+- **lastInbound**  -> li
+- **lastOutbound** -> lo
 
 ## User contextual information
 
 If an addon needs contextual information about the current Outreach user, it will need to add to manifest one or more user properties.
 
-Our end goal is to provide contextual access to any of the properties available through the [Outreach API](https://api.outreach.io/api/v2/docs#user), but at the moment we support in [SDK](../src/store/keys/UserContextKeys.ts) next properties:
+Our end goal is to provide contextual access to any of the properties available through the [Outreach API](https://api.outreach.io/api/v2/docs#user), but at the moment, we support in [SDK](../src/store/keys/UserContextKeys.ts) next properties:
 
 - **usr.email** The email address of the user.
 - **usr.fname** The first name of the user.
 - **usr.id** user id.
 - **ust.lname** The last name of the user.
-- **usr.tit** The user's job title (e.g. "Staff Accountant").
+- **usr.tit** The user's job title (e.g., "Staff Accountant").
 - **usr.uname** A reader-friendly unique identifier of the user.
 - **usr.csf1** to **usr.csf5** the value of the (1-5) user's custom field.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.1.44",
+  "version": "0.1.46",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/context/ExternalProspectContext.ts
+++ b/src/context/ExternalProspectContext.ts
@@ -1,0 +1,66 @@
+import { ExternalProspectProvider } from './ExternalProspectProvider';
+
+/**
+ * Definition of the prospect in the external data provider
+ * which is linked with Outreach prospect data.
+ *
+ * @export
+ * @class ExternalProspectContext
+ */
+export class ExternalProspectContext {
+  /**
+   *Type of external prospect data provider.
+   *
+   * @type {ExternalProspectProvider}
+   * @memberof ExternalProspectContext
+   */
+  public provider: ExternalProspectProvider;
+
+  /**
+   * Is external provider plugin integration enabled?
+   *
+   * @type {boolean}
+   * @memberof ExternalProspectContext
+   */
+  public enabled: boolean;
+
+  /**
+   * External data provider prospect id
+   *
+   * @type {string}
+   * @memberof ExternalProspectContext
+   */
+  public id: string;
+
+  /**
+   * External data provider prospect name
+   *
+   * @type {(string | null)}
+   * @memberof ExternalProspectContext
+   */
+  public name?: string | null;
+
+  /**
+   * External data provider type.
+   *
+   * @type {string}
+   * @memberof ExternalProspectContext
+   */
+  public type: string;
+
+  /**
+   * The date of last data inbound operation.
+   *
+   * @type {Date}
+   * @memberof ExternalProspectContext
+   */
+  public lastInbound?: Date | null;
+
+  /**
+   * The date of last data outbound operation.
+   *
+   * @type {(Date | null)}
+   * @memberof ExternalProspectContext
+   */
+  public lastOutbound?: Date | null;
+}

--- a/src/context/ExternalProspectProvider.ts
+++ b/src/context/ExternalProspectProvider.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-vars */
+export enum ExternalProspectProvider {
+  /**
+   * Usage of this enum value points to application error.
+   */
+  UNDEFINED = 0,
+
+  /**
+   * Salesforce plugin data source
+   */
+  SALESFORCE = 1,
+
+  /**
+   * Salesforce sandbox plugin data source
+   */
+  SALESFORCE_SANDBOX = 2,
+
+  /**
+   * Dynamics plugin data source
+   */
+  DYNAMICS = 2,
+}

--- a/src/context/ExternalProspectUtils.ts
+++ b/src/context/ExternalProspectUtils.ts
@@ -1,0 +1,67 @@
+import { ExternalProspectContext } from './ExternalProspectContext';
+import { ExternalProspectProvider } from './ExternalProspectProvider';
+
+export interface PackedProvider {
+  e: boolean;
+  i: string;
+  n?: string | null;
+  p: ExternalProspectProvider;
+  t: string;
+  li?: Date | null;
+  lo?: Date | null;
+}
+
+export default class externalProspectUtils {
+  /**
+   * Packs the contextual provider information to a shorter format
+   * which is more suitable for url usage.
+   *
+   * @static
+   * @param {ExternalProspectContext[]} contexts
+   * @returns {string}
+   * @memberof ExternalProspectUtils
+   */
+  public static pack(contexts: ExternalProspectContext[]): string {
+    const packedProviders: PackedProvider[] = [];
+    contexts.forEach((context) => {
+      packedProviders.push({
+        e: context.enabled,
+        i: context.id,
+        n: context.name,
+        p: context.provider,
+        t: context.type,
+        li: context.lastInbound,
+        lo: context.lastOutbound,
+      });
+    });
+
+    return JSON.stringify(packedProviders);
+  }
+
+  /**
+   * Unpacks the packed format of the external prospect information
+   *
+   * @memberof ExternalProspectContexts
+   */
+  public static unpack = (packed: string): ExternalProspectContext[] => {
+    const providers: ExternalProspectContext[] = [];
+    try {
+      const packedProviders = JSON.parse(packed) as PackedProvider[];
+      packedProviders.forEach((pp) => {
+        providers.push({
+          enabled: pp.e,
+          id: pp.i,
+          lastInbound: pp.li ? new Date(pp.li) : null,
+          lastOutbound: pp.lo ? new Date(pp.lo) : null,
+          name: pp.n,
+          provider: pp.p,
+          type: pp.t,
+        } as ExternalProspectContext);
+      });
+    } catch (err) {
+      console.error("Can't unpack the provider info", { err, packed });
+    }
+
+    return providers;
+  };
+}

--- a/src/context/ExternalProspectUtils.ts
+++ b/src/context/ExternalProspectUtils.ts
@@ -11,7 +11,7 @@ export interface PackedProvider {
   lo?: Date | null;
 }
 
-export default class externalProspectUtils {
+export class ExternalProspectUtils {
   /**
    * Packs the contextual provider information to a shorter format
    * which is more suitable for url usage.
@@ -21,7 +21,7 @@ export default class externalProspectUtils {
    * @returns {string}
    * @memberof ExternalProspectUtils
    */
-  public static pack(contexts: ExternalProspectContext[]): string {
+  public static pack = (contexts: ExternalProspectContext[]): string => {
     const packedProviders: PackedProvider[] = [];
     contexts.forEach((context) => {
       packedProviders.push({
@@ -36,7 +36,7 @@ export default class externalProspectUtils {
     });
 
     return JSON.stringify(packedProviders);
-  }
+  };
 
   /**
    * Unpacks the packed format of the external prospect information

--- a/src/context/ProspectContext.ts
+++ b/src/context/ProspectContext.ts
@@ -1,463 +1,476 @@
 import { ProspectContextKeys } from '../store/keys/ProspectContextKeys';
 // eslint-disable-next-line no-unused-vars
 import { ContextParam } from './ContextParam';
-import { CustomContext } from './CustomContext'
+import { CustomContext } from './CustomContext';
+import { ExternalProspectContext } from './ExternalProspectContext';
+import externalProspectUtils from './ExternalProspectUtils';
 
 export class ProspectContext extends CustomContext {
-    /**
-     * The date and time the prospect is available to contact again.
-     *
-     * @type {Date}
-     * @memberof OpportunityContext
-     */
-    availableAt: Date;
+  /**
+   * The date and time the prospect is available to contact again.
+   *
+   * @type {Date}
+   * @memberof OpportunityContext
+   */
+  availableAt: Date;
 
-    /**
-     * The name of the company the prospect works at. If associated with an account,
-     * this is the name of the account. (e.g. Acme International).
-     *
-     * @type {string}
-     * @memberof ProspectContext
-     */
-    company: string;
+  /**
+   * The name of the company the prospect works at. If associated with an account,
+   * this is the name of the account. (e.g. Acme International).
+   *
+   * @type {string}
+   * @memberof ProspectContext
+   */
+  company: string;
 
-    /**
-     * The locality of prospect’s company.
-     *
-     * @type {string}
-     * @memberof ProspectContext
-     */
-    companyLocality: string;
+  /**
+   * The locality of prospect’s company.
+   *
+   * @type {string}
+   * @memberof ProspectContext
+   */
+  companyLocality: string;
 
-    /**
-     * A list of email addresses associated with the prospect.
-     *
-     * @type {string[]}
-     * @memberof ProspectContext
-     */
-    emails: string[]
+  /**
+   * A list of email addresses associated with the prospect.
+   *
+   * @type {string[]}
+   * @memberof ProspectContext
+   */
+  emails: string[];
 
-    /**
-     * Unique prospect identifier.
-     *
-     * @type {string}
-     * @memberof OpportunityContext
-     */
-    id?: string;
+  /**
+   * Unique prospect identifier.
+   *
+   * @type {string}
+   * @memberof OpportunityContext
+   */
+  id?: string;
 
-    /**
-     * Tags associated with the opportunity.
-     *
-     * @type {string}
-     * @memberof OpportunityContext
-     */
-    tags: string;
+  /**
+   * Tags associated with the opportunity.
+   *
+   * @type {string}
+   * @memberof OpportunityContext
+   */
+  tags: string;
 
-    /**
-     * The prospect’s current timezone, preferably in the IANA format (e.g. "America/LosAngeles").
-     */
-    timezone: string;
+  /**
+   * The prospect’s current timezone, preferably in the IANA format (e.g. "America/LosAngeles").
+   */
+  timezone: string;
 
-    /**
-     * The title of the prospect.
-     */
-    title: string;
+  /**
+   * The title of the prospect.
+   */
+  title: string;
 
-    /**
-     * Attempts to initialize the opportunity context with a given parameter.
-     *
-     * @memberof OpportunityContext
-     */
-    public initFrom = (param: ContextParam): boolean => {
-      switch (param.key) {
-        case ProspectContextKeys.AVAILABLE_AT:
-          this.availableAt = new Date(param.value);
-          break;
-        case ProspectContextKeys.COMPANY:
-          this.company = param.value;
-          break;
-        case ProspectContextKeys.COMPANY_LOCALITY:
-          this.companyLocality = param.value;
-          break;
-        case ProspectContextKeys.ID:
-          this.id = param.value;
-          break;
-        case ProspectContextKeys.TAGS:
-          this.tags = param.value;
-          break;
-        case ProspectContextKeys.TIMEZONE:
-          this.timezone = param.value;
-          break;
-        case ProspectContextKeys.TITLE:
-          this.title = param.value;
-          break;
+  /**
+   * Collection of zero or more external provider data current prospect has in external systems
+   * which are linked through installed Outreach plugins.
+   *
+   * @type {ExternalProspectContext[]}
+   * @memberof ProspectContext
+   */
+  externalInfo: ExternalProspectContext[] = [];
 
-        case ProspectContextKeys.CUSTOM_FIELD_1:
-          this.customField1 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_2:
-          this.customField2 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_3:
-          this.customField3 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_4:
-          this.customField4 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_5:
-          this.customField5 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_6:
-          this.customField6 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_7:
-          this.customField7 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_8:
-          this.customField8 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_9:
-          this.customField9 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_10:
-          this.customField10 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_11:
-          this.customField11 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_12:
-          this.customField12 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_13:
-          this.customField13 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_14:
-          this.customField14 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_15:
-          this.customField15 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_16:
-          this.customField16 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_17:
-          this.customField17 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_18:
-          this.customField18 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_19:
-          this.customField19 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_20:
-          this.customField20 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_21:
-          this.customField21 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_22:
-          this.customField22 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_23:
-          this.customField23 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_24:
-          this.customField24 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_25:
-          this.customField25 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_26:
-          this.customField26 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_27:
-          this.customField27 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_28:
-          this.customField28 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_29:
-          this.customField29 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_30:
-          this.customField30 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_31:
-          this.customField31 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_32:
-          this.customField32 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_33:
-          this.customField33 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_34:
-          this.customField34 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_35:
-          this.customField35 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_36:
-          this.customField36 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_37:
-          this.customField37 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_38:
-          this.customField38 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_39:
-          this.customField39 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_40:
-          this.customField40 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_41:
-          this.customField41 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_42:
-          this.customField42 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_43:
-          this.customField43 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_44:
-          this.customField44 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_45:
-          this.customField45 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_46:
-          this.customField46 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_47:
-          this.customField47 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_48:
-          this.customField48 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_49:
-          this.customField49 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_50:
-          this.customField50 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_51:
-          this.customField51 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_52:
-          this.customField52 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_53:
-          this.customField53 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_54:
-          this.customField54 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_55:
-          this.customField55 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_56:
-          this.customField56 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_57:
-          this.customField57 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_58:
-          this.customField58 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_59:
-          this.customField59 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_60:
-          this.customField60 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_61:
-          this.customField61 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_62:
-          this.customField62 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_63:
-          this.customField63 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_64:
-          this.customField64 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_65:
-          this.customField65 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_66:
-          this.customField66 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_67:
-          this.customField67 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_68:
-          this.customField68 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_69:
-          this.customField69 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_70:
-          this.customField70 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_71:
-          this.customField71 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_72:
-          this.customField72 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_73:
-          this.customField73 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_74:
-          this.customField74 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_75:
-          this.customField75 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_76:
-          this.customField76 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_77:
-          this.customField77 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_78:
-          this.customField78 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_79:
-          this.customField79 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_80:
-          this.customField80 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_81:
-          this.customField81 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_82:
-          this.customField82 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_83:
-          this.customField83 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_84:
-          this.customField84 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_85:
-          this.customField85 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_86:
-          this.customField86 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_87:
-          this.customField87 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_88:
-          this.customField88 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_89:
-          this.customField89 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_90:
-          this.customField90 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_91:
-          this.customField91 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_92:
-          this.customField92 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_93:
-          this.customField93 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_94:
-          this.customField94 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_95:
-          this.customField95 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_96:
-          this.customField96 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_97:
-          this.customField97 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_98:
-          this.customField98 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_99:
-          this.customField99 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_100:
-          this.customField100 = param.value;
-          break;
+  /**
+   * Attempts to initialize the opportunity context with a given parameter.
+   *
+   * @memberof OpportunityContext
+   */
+  public initFrom = (param: ContextParam): boolean => {
+    switch (param.key) {
+      case ProspectContextKeys.AVAILABLE_AT:
+        this.availableAt = new Date(param.value);
+        break;
+      case ProspectContextKeys.COMPANY:
+        this.company = param.value;
+        break;
+      case ProspectContextKeys.COMPANY_LOCALITY:
+        this.companyLocality = param.value;
+        break;
+      case ProspectContextKeys.ID:
+        this.id = param.value;
+        break;
+      case ProspectContextKeys.TAGS:
+        this.tags = param.value;
+        break;
+      case ProspectContextKeys.TIMEZONE:
+        this.timezone = param.value;
+        break;
+      case ProspectContextKeys.TITLE:
+        this.title = param.value;
+        break;
+      case ProspectContextKeys.EXTERNAL:
+        this.externalInfo = externalProspectUtils.unpack(param.value);
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_1:
+        this.customField1 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_2:
+        this.customField2 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_3:
+        this.customField3 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_4:
+        this.customField4 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_5:
+        this.customField5 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_6:
+        this.customField6 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_7:
+        this.customField7 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_8:
+        this.customField8 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_9:
+        this.customField9 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_10:
+        this.customField10 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_11:
+        this.customField11 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_12:
+        this.customField12 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_13:
+        this.customField13 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_14:
+        this.customField14 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_15:
+        this.customField15 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_16:
+        this.customField16 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_17:
+        this.customField17 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_18:
+        this.customField18 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_19:
+        this.customField19 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_20:
+        this.customField20 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_21:
+        this.customField21 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_22:
+        this.customField22 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_23:
+        this.customField23 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_24:
+        this.customField24 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_25:
+        this.customField25 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_26:
+        this.customField26 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_27:
+        this.customField27 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_28:
+        this.customField28 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_29:
+        this.customField29 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_30:
+        this.customField30 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_31:
+        this.customField31 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_32:
+        this.customField32 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_33:
+        this.customField33 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_34:
+        this.customField34 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_35:
+        this.customField35 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_36:
+        this.customField36 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_37:
+        this.customField37 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_38:
+        this.customField38 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_39:
+        this.customField39 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_40:
+        this.customField40 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_41:
+        this.customField41 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_42:
+        this.customField42 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_43:
+        this.customField43 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_44:
+        this.customField44 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_45:
+        this.customField45 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_46:
+        this.customField46 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_47:
+        this.customField47 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_48:
+        this.customField48 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_49:
+        this.customField49 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_50:
+        this.customField50 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_51:
+        this.customField51 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_52:
+        this.customField52 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_53:
+        this.customField53 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_54:
+        this.customField54 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_55:
+        this.customField55 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_56:
+        this.customField56 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_57:
+        this.customField57 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_58:
+        this.customField58 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_59:
+        this.customField59 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_60:
+        this.customField60 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_61:
+        this.customField61 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_62:
+        this.customField62 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_63:
+        this.customField63 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_64:
+        this.customField64 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_65:
+        this.customField65 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_66:
+        this.customField66 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_67:
+        this.customField67 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_68:
+        this.customField68 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_69:
+        this.customField69 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_70:
+        this.customField70 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_71:
+        this.customField71 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_72:
+        this.customField72 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_73:
+        this.customField73 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_74:
+        this.customField74 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_75:
+        this.customField75 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_76:
+        this.customField76 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_77:
+        this.customField77 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_78:
+        this.customField78 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_79:
+        this.customField79 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_80:
+        this.customField80 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_81:
+        this.customField81 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_82:
+        this.customField82 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_83:
+        this.customField83 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_84:
+        this.customField84 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_85:
+        this.customField85 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_86:
+        this.customField86 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_87:
+        this.customField87 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_88:
+        this.customField88 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_89:
+        this.customField89 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_90:
+        this.customField90 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_91:
+        this.customField91 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_92:
+        this.customField92 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_93:
+        this.customField93 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_94:
+        this.customField94 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_95:
+        this.customField95 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_96:
+        this.customField96 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_97:
+        this.customField97 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_98:
+        this.customField98 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_99:
+        this.customField99 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_100:
+        this.customField100 = param.value;
+        break;
 
-        case ProspectContextKeys.CUSTOM_FIELD_101:
-          this.customField101 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_102:
-          this.customField102 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_103:
-          this.customField103 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_104:
-          this.customField104 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_105:
-          this.customField105 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_106:
-          this.customField106 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_107:
-          this.customField107 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_108:
-          this.customField108 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_109:
-          this.customField109 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_110:
-          this.customField110 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_111:
-          this.customField111 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_112:
-          this.customField112 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_113:
-          this.customField113 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_114:
-          this.customField114 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_115:
-          this.customField115 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_116:
-          this.customField116 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_117:
-          this.customField117 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_118:
-          this.customField118 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_119:
-          this.customField119 = param.value;
-          break;
-        case ProspectContextKeys.CUSTOM_FIELD_120:
-          this.customField120 = param.value;
-          break;
+      case ProspectContextKeys.CUSTOM_FIELD_101:
+        this.customField101 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_102:
+        this.customField102 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_103:
+        this.customField103 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_104:
+        this.customField104 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_105:
+        this.customField105 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_106:
+        this.customField106 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_107:
+        this.customField107 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_108:
+        this.customField108 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_109:
+        this.customField109 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_110:
+        this.customField110 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_111:
+        this.customField111 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_112:
+        this.customField112 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_113:
+        this.customField113 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_114:
+        this.customField114 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_115:
+        this.customField115 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_116:
+        this.customField116 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_117:
+        this.customField117 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_118:
+        this.customField118 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_119:
+        this.customField119 = param.value;
+        break;
+      case ProspectContextKeys.CUSTOM_FIELD_120:
+        this.customField120 = param.value;
+        break;
 
-        default:
-          return false;
-      }
-
-      return true;
+      default:
+        return false;
     }
+
+    return true;
+  };
 }

--- a/src/context/ProspectContext.ts
+++ b/src/context/ProspectContext.ts
@@ -3,7 +3,7 @@ import { ProspectContextKeys } from '../store/keys/ProspectContextKeys';
 import { ContextParam } from './ContextParam';
 import { CustomContext } from './CustomContext';
 import { ExternalProspectContext } from './ExternalProspectContext';
-import externalProspectUtils from './ExternalProspectUtils';
+import { ExternalProspectUtils } from './ExternalProspectUtils';
 
 export class ProspectContext extends CustomContext {
   /**
@@ -103,7 +103,7 @@ export class ProspectContext extends CustomContext {
         this.title = param.value;
         break;
       case ProspectContextKeys.EXTERNAL:
-        this.externalInfo = externalProspectUtils.unpack(param.value);
+        this.externalInfo = ExternalProspectUtils.unpack(param.value);
         break;
       case ProspectContextKeys.CUSTOM_FIELD_1:
         this.customField1 = param.value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,11 @@ import { LoadingContext } from './context/LoadingContext';
 export * from './context/AccountContext';
 export * from './context/ContextParam';
 export * from './context/CustomContext';
+
+export * from './context/ExternalProspectContext';
+export * from './context/ExternalProspectProvider';
+export * from './context/ExternalProspectUtils';
+
 export * from './context/LoadingContext';
 export * from './context/OpportunityContext';
 export * from './context/OutreachContext';

--- a/src/store/keys/AllContextKeys.ts
+++ b/src/store/keys/AllContextKeys.ts
@@ -5,8 +5,9 @@ import { OpportunityContextKeys } from './OpportunityContextKeys';
 import { ClientContextKeys } from './ClientContextKeys';
 import { ProspectContextKeys } from './ProspectContextKeys';
 
-export type AllContextKeys = UserContextKeys |
-                             AccountContextKeys |
-                             OpportunityContextKeys |
-                             ClientContextKeys |
-                             ProspectContextKeys;
+export type AllContextKeys =
+  | UserContextKeys
+  | AccountContextKeys
+  | OpportunityContextKeys
+  | ClientContextKeys
+  | ProspectContextKeys;

--- a/src/store/keys/ProspectContextKeys.ts
+++ b/src/store/keys/ProspectContextKeys.ts
@@ -7,171 +7,176 @@
  * @enum {number}
  */
 export enum ProspectContextKeys {
-    /**
-     * The date and time the prospect is available to contact again.
-     */
-    AVAILABLE_AT = 'pro.avail',
+  /**
+   * The date and time the prospect is available to contact again.
+   */
+  AVAILABLE_AT = 'pro.avail',
 
-    /**
-     * The name of the company the prospect works at.
-     * If associated with an account, this is the name of the account. (e.g. Acme International).
-     */
-    COMPANY = 'pro.comp',
+  /**
+   * The name of the company the prospect works at.
+   * If associated with an account, this is the name of the account. (e.g. Acme International).
+   */
+  COMPANY = 'pro.comp',
 
-    /**
-     * The locality of prospect’s company.
-     */
-    COMPANY_LOCALITY = 'pro.loc',
-    /**
-     * Prospect id
-     */
-    ID = 'pro.id',
+  /**
+   * The locality of prospect’s company.
+   */
+  COMPANY_LOCALITY = 'pro.loc',
+  /**
+   * Prospect id
+   */
+  ID = 'pro.id',
 
-    /**
-     * A list of tag values associated with the account (e.g. ["Interested", "2017 Expo"]).
-     */
-    TAGS = 'pro.tags',
+  /**
+   * A list of tag values associated with the account (e.g. ["Interested", "2017 Expo"]).
+   */
+  TAGS = 'pro.tags',
 
-    /**
-     * The prospect’s current timezone, preferably in the IANA format (e.g. "America/LosAngeles").
-     */
-    TIMEZONE = 'pro.tzone',
+  /**
+   * The prospect’s current timezone, preferably in the IANA format (e.g. "America/LosAngeles").
+   */
+  TIMEZONE = 'pro.tzone',
 
-    /**
-     * The title of the prospect.
-     */
-    TITLE = 'pro.title',
+  /**
+   * The title of the prospect.
+   */
+  TITLE = 'pro.title',
 
-    CUSTOM_FIELD_1 = 'pro.csf1',
-    CUSTOM_FIELD_2 = 'pro.csf2',
-    CUSTOM_FIELD_3 = 'pro.csf3',
-    CUSTOM_FIELD_4 = 'pro.csf4',
-    CUSTOM_FIELD_5 = 'pro.csf5',
-    CUSTOM_FIELD_6 = 'pro.csf6',
-    CUSTOM_FIELD_7 = 'pro.csf7',
-    CUSTOM_FIELD_8 = 'pro.csf8',
-    CUSTOM_FIELD_9 = 'pro.csf9',
+  /**
+   *The prospect's external information received from the installed plugins (Salesforce, Dynamics etc.)
+   */
+  EXTERNAL = 'pro.ext',
 
-    CUSTOM_FIELD_10 = 'pro.csf10',
-    CUSTOM_FIELD_11 = 'pro.csf11',
-    CUSTOM_FIELD_12 = 'pro.csf12',
-    CUSTOM_FIELD_13 = 'pro.csf13',
-    CUSTOM_FIELD_14 = 'pro.csf14',
-    CUSTOM_FIELD_15 = 'pro.csf15',
-    CUSTOM_FIELD_16 = 'pro.csf16',
-    CUSTOM_FIELD_17 = 'pro.csf17',
-    CUSTOM_FIELD_18 = 'pro.csf18',
-    CUSTOM_FIELD_19 = 'pro.csf19',
+  CUSTOM_FIELD_1 = 'pro.csf1',
+  CUSTOM_FIELD_2 = 'pro.csf2',
+  CUSTOM_FIELD_3 = 'pro.csf3',
+  CUSTOM_FIELD_4 = 'pro.csf4',
+  CUSTOM_FIELD_5 = 'pro.csf5',
+  CUSTOM_FIELD_6 = 'pro.csf6',
+  CUSTOM_FIELD_7 = 'pro.csf7',
+  CUSTOM_FIELD_8 = 'pro.csf8',
+  CUSTOM_FIELD_9 = 'pro.csf9',
 
-    CUSTOM_FIELD_20 = 'pro.csf20',
-    CUSTOM_FIELD_21 = 'pro.csf21',
-    CUSTOM_FIELD_22 = 'pro.csf22',
-    CUSTOM_FIELD_23 = 'pro.csf23',
-    CUSTOM_FIELD_24 = 'pro.csf24',
-    CUSTOM_FIELD_25 = 'pro.csf25',
-    CUSTOM_FIELD_26 = 'pro.csf26',
-    CUSTOM_FIELD_27 = 'pro.csf27',
-    CUSTOM_FIELD_28 = 'pro.csf28',
-    CUSTOM_FIELD_29 = 'pro.csf29',
+  CUSTOM_FIELD_10 = 'pro.csf10',
+  CUSTOM_FIELD_11 = 'pro.csf11',
+  CUSTOM_FIELD_12 = 'pro.csf12',
+  CUSTOM_FIELD_13 = 'pro.csf13',
+  CUSTOM_FIELD_14 = 'pro.csf14',
+  CUSTOM_FIELD_15 = 'pro.csf15',
+  CUSTOM_FIELD_16 = 'pro.csf16',
+  CUSTOM_FIELD_17 = 'pro.csf17',
+  CUSTOM_FIELD_18 = 'pro.csf18',
+  CUSTOM_FIELD_19 = 'pro.csf19',
 
-    CUSTOM_FIELD_30 = 'pro.csf30',
-    CUSTOM_FIELD_31 = 'pro.csf31',
-    CUSTOM_FIELD_32 = 'pro.csf32',
-    CUSTOM_FIELD_33 = 'pro.csf33',
-    CUSTOM_FIELD_34 = 'pro.csf34',
-    CUSTOM_FIELD_35 = 'pro.csf35',
-    CUSTOM_FIELD_36 = 'pro.csf36',
-    CUSTOM_FIELD_37 = 'pro.csf37',
-    CUSTOM_FIELD_38 = 'pro.csf38',
-    CUSTOM_FIELD_39 = 'pro.csf39',
+  CUSTOM_FIELD_20 = 'pro.csf20',
+  CUSTOM_FIELD_21 = 'pro.csf21',
+  CUSTOM_FIELD_22 = 'pro.csf22',
+  CUSTOM_FIELD_23 = 'pro.csf23',
+  CUSTOM_FIELD_24 = 'pro.csf24',
+  CUSTOM_FIELD_25 = 'pro.csf25',
+  CUSTOM_FIELD_26 = 'pro.csf26',
+  CUSTOM_FIELD_27 = 'pro.csf27',
+  CUSTOM_FIELD_28 = 'pro.csf28',
+  CUSTOM_FIELD_29 = 'pro.csf29',
 
-    CUSTOM_FIELD_40 = 'pro.csf40',
-    CUSTOM_FIELD_41 = 'pro.csf41',
-    CUSTOM_FIELD_42 = 'pro.csf42',
-    CUSTOM_FIELD_43 = 'pro.csf43',
-    CUSTOM_FIELD_44 = 'pro.csf44',
-    CUSTOM_FIELD_45 = 'pro.csf45',
-    CUSTOM_FIELD_46 = 'pro.csf46',
-    CUSTOM_FIELD_47 = 'pro.csf47',
-    CUSTOM_FIELD_48 = 'pro.csf48',
-    CUSTOM_FIELD_49 = 'pro.csf49',
+  CUSTOM_FIELD_30 = 'pro.csf30',
+  CUSTOM_FIELD_31 = 'pro.csf31',
+  CUSTOM_FIELD_32 = 'pro.csf32',
+  CUSTOM_FIELD_33 = 'pro.csf33',
+  CUSTOM_FIELD_34 = 'pro.csf34',
+  CUSTOM_FIELD_35 = 'pro.csf35',
+  CUSTOM_FIELD_36 = 'pro.csf36',
+  CUSTOM_FIELD_37 = 'pro.csf37',
+  CUSTOM_FIELD_38 = 'pro.csf38',
+  CUSTOM_FIELD_39 = 'pro.csf39',
 
-    CUSTOM_FIELD_50 = 'pro.csf50',
-    CUSTOM_FIELD_51 = 'pro.csf51',
-    CUSTOM_FIELD_52 = 'pro.csf52',
-    CUSTOM_FIELD_53 = 'pro.csf53',
-    CUSTOM_FIELD_54 = 'pro.csf54',
-    CUSTOM_FIELD_55 = 'pro.csf55',
-    CUSTOM_FIELD_56 = 'pro.csf56',
-    CUSTOM_FIELD_57 = 'pro.csf57',
-    CUSTOM_FIELD_58 = 'pro.csf58',
-    CUSTOM_FIELD_59 = 'pro.csf59',
+  CUSTOM_FIELD_40 = 'pro.csf40',
+  CUSTOM_FIELD_41 = 'pro.csf41',
+  CUSTOM_FIELD_42 = 'pro.csf42',
+  CUSTOM_FIELD_43 = 'pro.csf43',
+  CUSTOM_FIELD_44 = 'pro.csf44',
+  CUSTOM_FIELD_45 = 'pro.csf45',
+  CUSTOM_FIELD_46 = 'pro.csf46',
+  CUSTOM_FIELD_47 = 'pro.csf47',
+  CUSTOM_FIELD_48 = 'pro.csf48',
+  CUSTOM_FIELD_49 = 'pro.csf49',
 
-    CUSTOM_FIELD_60 = 'pro.csf60',
-    CUSTOM_FIELD_61 = 'pro.csf61',
-    CUSTOM_FIELD_62 = 'pro.csf62',
-    CUSTOM_FIELD_63 = 'pro.csf63',
-    CUSTOM_FIELD_64 = 'pro.csf64',
-    CUSTOM_FIELD_65 = 'pro.csf65',
-    CUSTOM_FIELD_66 = 'pro.csf66',
-    CUSTOM_FIELD_67 = 'pro.csf67',
-    CUSTOM_FIELD_68 = 'pro.csf68',
-    CUSTOM_FIELD_69 = 'pro.csf69',
+  CUSTOM_FIELD_50 = 'pro.csf50',
+  CUSTOM_FIELD_51 = 'pro.csf51',
+  CUSTOM_FIELD_52 = 'pro.csf52',
+  CUSTOM_FIELD_53 = 'pro.csf53',
+  CUSTOM_FIELD_54 = 'pro.csf54',
+  CUSTOM_FIELD_55 = 'pro.csf55',
+  CUSTOM_FIELD_56 = 'pro.csf56',
+  CUSTOM_FIELD_57 = 'pro.csf57',
+  CUSTOM_FIELD_58 = 'pro.csf58',
+  CUSTOM_FIELD_59 = 'pro.csf59',
 
-    CUSTOM_FIELD_70 = 'pro.csf70',
-    CUSTOM_FIELD_71 = 'pro.csf71',
-    CUSTOM_FIELD_72 = 'pro.csf72',
-    CUSTOM_FIELD_73 = 'pro.csf73',
-    CUSTOM_FIELD_74 = 'pro.csf74',
-    CUSTOM_FIELD_75 = 'pro.csf75',
-    CUSTOM_FIELD_76 = 'pro.csf76',
-    CUSTOM_FIELD_77 = 'pro.csf77',
-    CUSTOM_FIELD_78 = 'pro.csf78',
-    CUSTOM_FIELD_79 = 'pro.csf79',
+  CUSTOM_FIELD_60 = 'pro.csf60',
+  CUSTOM_FIELD_61 = 'pro.csf61',
+  CUSTOM_FIELD_62 = 'pro.csf62',
+  CUSTOM_FIELD_63 = 'pro.csf63',
+  CUSTOM_FIELD_64 = 'pro.csf64',
+  CUSTOM_FIELD_65 = 'pro.csf65',
+  CUSTOM_FIELD_66 = 'pro.csf66',
+  CUSTOM_FIELD_67 = 'pro.csf67',
+  CUSTOM_FIELD_68 = 'pro.csf68',
+  CUSTOM_FIELD_69 = 'pro.csf69',
 
-    CUSTOM_FIELD_80 = 'pro.csf80',
-    CUSTOM_FIELD_81 = 'pro.csf81',
-    CUSTOM_FIELD_82 = 'pro.csf82',
-    CUSTOM_FIELD_83 = 'pro.csf83',
-    CUSTOM_FIELD_84 = 'pro.csf84',
-    CUSTOM_FIELD_85 = 'pro.csf85',
-    CUSTOM_FIELD_86 = 'pro.csf86',
-    CUSTOM_FIELD_87 = 'pro.csf87',
-    CUSTOM_FIELD_88 = 'pro.csf88',
-    CUSTOM_FIELD_89 = 'pro.csf89',
+  CUSTOM_FIELD_70 = 'pro.csf70',
+  CUSTOM_FIELD_71 = 'pro.csf71',
+  CUSTOM_FIELD_72 = 'pro.csf72',
+  CUSTOM_FIELD_73 = 'pro.csf73',
+  CUSTOM_FIELD_74 = 'pro.csf74',
+  CUSTOM_FIELD_75 = 'pro.csf75',
+  CUSTOM_FIELD_76 = 'pro.csf76',
+  CUSTOM_FIELD_77 = 'pro.csf77',
+  CUSTOM_FIELD_78 = 'pro.csf78',
+  CUSTOM_FIELD_79 = 'pro.csf79',
 
-    CUSTOM_FIELD_90 = 'pro.csf90',
-    CUSTOM_FIELD_91 = 'pro.csf91',
-    CUSTOM_FIELD_92 = 'pro.csf92',
-    CUSTOM_FIELD_93 = 'pro.csf93',
-    CUSTOM_FIELD_94 = 'pro.csf94',
-    CUSTOM_FIELD_95 = 'pro.csf95',
-    CUSTOM_FIELD_96 = 'pro.csf96',
-    CUSTOM_FIELD_97 = 'pro.csf97',
-    CUSTOM_FIELD_98 = 'pro.csf98',
-    CUSTOM_FIELD_99 = 'pro.csf99',
+  CUSTOM_FIELD_80 = 'pro.csf80',
+  CUSTOM_FIELD_81 = 'pro.csf81',
+  CUSTOM_FIELD_82 = 'pro.csf82',
+  CUSTOM_FIELD_83 = 'pro.csf83',
+  CUSTOM_FIELD_84 = 'pro.csf84',
+  CUSTOM_FIELD_85 = 'pro.csf85',
+  CUSTOM_FIELD_86 = 'pro.csf86',
+  CUSTOM_FIELD_87 = 'pro.csf87',
+  CUSTOM_FIELD_88 = 'pro.csf88',
+  CUSTOM_FIELD_89 = 'pro.csf89',
 
-    CUSTOM_FIELD_100 = 'pro.csf100',
-    CUSTOM_FIELD_101 = 'pro.csf101',
-    CUSTOM_FIELD_102 = 'pro.csf102',
-    CUSTOM_FIELD_103 = 'pro.csf103',
-    CUSTOM_FIELD_104 = 'pro.csf104',
-    CUSTOM_FIELD_105 = 'pro.csf105',
-    CUSTOM_FIELD_106 = 'pro.csf106',
-    CUSTOM_FIELD_107 = 'pro.csf107',
-    CUSTOM_FIELD_108 = 'pro.csf108',
-    CUSTOM_FIELD_109 = 'pro.csf109',
+  CUSTOM_FIELD_90 = 'pro.csf90',
+  CUSTOM_FIELD_91 = 'pro.csf91',
+  CUSTOM_FIELD_92 = 'pro.csf92',
+  CUSTOM_FIELD_93 = 'pro.csf93',
+  CUSTOM_FIELD_94 = 'pro.csf94',
+  CUSTOM_FIELD_95 = 'pro.csf95',
+  CUSTOM_FIELD_96 = 'pro.csf96',
+  CUSTOM_FIELD_97 = 'pro.csf97',
+  CUSTOM_FIELD_98 = 'pro.csf98',
+  CUSTOM_FIELD_99 = 'pro.csf99',
 
-    CUSTOM_FIELD_110 = 'pro.csf110',
-    CUSTOM_FIELD_111 = 'pro.csf111',
-    CUSTOM_FIELD_112 = 'pro.csf112',
-    CUSTOM_FIELD_113 = 'pro.csf113',
-    CUSTOM_FIELD_114 = 'pro.csf114',
-    CUSTOM_FIELD_115 = 'pro.csf115',
-    CUSTOM_FIELD_116 = 'pro.csf116',
-    CUSTOM_FIELD_117 = 'pro.csf117',
-    CUSTOM_FIELD_118 = 'pro.csf118',
-    CUSTOM_FIELD_119 = 'pro.csf119',
+  CUSTOM_FIELD_100 = 'pro.csf100',
+  CUSTOM_FIELD_101 = 'pro.csf101',
+  CUSTOM_FIELD_102 = 'pro.csf102',
+  CUSTOM_FIELD_103 = 'pro.csf103',
+  CUSTOM_FIELD_104 = 'pro.csf104',
+  CUSTOM_FIELD_105 = 'pro.csf105',
+  CUSTOM_FIELD_106 = 'pro.csf106',
+  CUSTOM_FIELD_107 = 'pro.csf107',
+  CUSTOM_FIELD_108 = 'pro.csf108',
+  CUSTOM_FIELD_109 = 'pro.csf109',
 
-    CUSTOM_FIELD_120 = 'pro.csf120',
+  CUSTOM_FIELD_110 = 'pro.csf110',
+  CUSTOM_FIELD_111 = 'pro.csf111',
+  CUSTOM_FIELD_112 = 'pro.csf112',
+  CUSTOM_FIELD_113 = 'pro.csf113',
+  CUSTOM_FIELD_114 = 'pro.csf114',
+  CUSTOM_FIELD_115 = 'pro.csf115',
+  CUSTOM_FIELD_116 = 'pro.csf116',
+  CUSTOM_FIELD_117 = 'pro.csf117',
+  CUSTOM_FIELD_118 = 'pro.csf118',
+  CUSTOM_FIELD_119 = 'pro.csf119',
+
+  CUSTOM_FIELD_120 = 'pro.csf120',
 }

--- a/tests/external.pack.test.ts
+++ b/tests/external.pack.test.ts
@@ -1,0 +1,33 @@
+import { ExternalProspectContext, ExternalProspectProvider } from '../src';
+import externalProspectUtils from '../src/context/ExternalProspectUtils';
+
+describe('ExternalProspectProviders tests', () => {
+  test('pack/unpack works fine', () => {
+    const now = new Date();
+    const externalContexts: ExternalProspectContext[] = [
+      {
+        enabled: true,
+        id: '123',
+        name: null,
+        provider: ExternalProspectProvider.SALESFORCE,
+        type: 'Lead',
+        lastInbound: now,
+        lastOutbound: null,
+      },
+      {
+        enabled: false,
+        id: '456',
+        name: 'name',
+        provider: ExternalProspectProvider.SALESFORCE_SANDBOX,
+        type: 'Test',
+        lastInbound: null,
+        lastOutbound: now,
+      },
+    ];
+
+    const packedContext = externalProspectUtils.pack(externalContexts);
+    const unpackedContext = externalProspectUtils.unpack(packedContext);
+
+    expect(externalContexts).toStrictEqual(unpackedContext);
+  });
+});

--- a/tests/external.pack.test.ts
+++ b/tests/external.pack.test.ts
@@ -1,5 +1,5 @@
 import { ExternalProspectContext, ExternalProspectProvider } from '../src';
-import externalProspectUtils from '../src/context/ExternalProspectUtils';
+import { ExternalProspectUtils } from '../src/context/ExternalProspectUtils';
 
 describe('ExternalProspectProviders tests', () => {
   test('pack/unpack works fine', () => {
@@ -25,8 +25,8 @@ describe('ExternalProspectProviders tests', () => {
       },
     ];
 
-    const packedContext = externalProspectUtils.pack(externalContexts);
-    const unpackedContext = externalProspectUtils.unpack(packedContext);
+    const packedContext = ExternalProspectUtils.pack(externalContexts);
+    const unpackedContext = ExternalProspectUtils.unpack(packedContext);
 
     expect(externalContexts).toStrictEqual(unpackedContext);
   });


### PR DESCRIPTION
[OREX-146]

Adds SDK support for **pro.ext** manifest property allowing addon creators to request external information prospect receives through the linked Outreach plugins for Salesforce, Salesforce sandbox and Dynamics plugins.

[OREX-146]: https://outreach-io.atlassian.net/browse/OREX-146