### PR TITLE
#OREX-409 NotificationUrl (sdk part) 

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -18,6 +18,7 @@ Table of content:
       - [type](#type)
       - [url](#url)
       - [icon](#icon)
+      - [notificationsUrl](#notificationsurl)
       - [environment](#environment)
     - [author](#author)
   - [Integration manifest properties](#integration-manifest-properties)
@@ -60,12 +61,13 @@ Here is the sample manifest file of the hello world addon
   },
   "host": {
     "type": "tab-opportunity",
-    "url": "https://addon-host.com/something",
+    "url": "https://addon-host.com/addon",
     "icon": "https://addon-host.com/icon.png",
     "environment": {
       "fullWidth": true,
       "decoration": "simple"
-    }
+    },
+    "notificationsUrl": "https://addon-host.com/notification",
   },
   "author": {
     "company": "Contoso Ltd",
@@ -224,6 +226,15 @@ http://somesite.com/something/456?oid=123
 #### icon
 
 base64 string represents the icon to be shown in the addon store and (if possible) in the Outreach client.
+
+#### notificationsUrl
+
+This is optional address of the endpoint serving notification centric version of the addon experience.
+
+If defined, this endpoint will serve an empty HTML page with SDK on it, and the Outreach app will load it early without the need for user interaction. 
+That's how addon can update badge decoration and invite Outreach user to open full addon experience as defined in host.url property.
+
+Only addons of AddonType.LeftSideMenu type can only use this property.
 
 #### environment
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/sdk/Validator.ts
+++ b/src/sdk/Validator.ts
@@ -204,6 +204,22 @@ export const validate = (manifest: Manifest): string[] => {
     ) {
       issues.push('Host type  is invalid. Value: ' + manifest.host.type);
     }
+
+    if (manifest.host.notificationsUrl) {
+      if (!urlValidation(manifest.host.notificationsUrl)) {
+        issues.push(
+          'Notifications url definition is invalid url. Value: ' +
+            manifest.host.notificationsUrl
+        );
+      }
+
+      if (manifest.host.type !== AddonType.LeftSideMenu) {
+        issues.push(
+          'Notifications url can be defined only for left-side-menu addon. Type: ' +
+            manifest.host.type
+        );
+      }
+    }
   }
 
   if (!manifest.identifier) {

--- a/src/store/ManifestHost.ts
+++ b/src/store/ManifestHost.ts
@@ -14,7 +14,7 @@ export class ManifestHost {
    * Type property defines what the type of addon is and where it should be loaded.
    * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#type
    * @type {AddonType}
-   * @memberof Host
+   * @memberof ManifestHost
    */
   type: AddonType;
 
@@ -23,7 +23,7 @@ export class ManifestHost {
    *
    * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#url
    * @type {string}
-   * @memberof Host
+   * @memberof ManifestHost
    */
   url: string;
 
@@ -33,7 +33,7 @@ export class ManifestHost {
    *
    * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#icon
    * @type {string}
-   * @memberof Host
+   * @memberof ManifestHost
    */
   icon: string;
 
@@ -44,4 +44,20 @@ export class ManifestHost {
    * @memberof ManifestHost
    */
   environment?: ManifestHostEnvironment;
+
+  /**
+   * Optional address of the endpoint serving notification centric version of the addon experience.
+   *
+   * If defined, this endpoint will serve an empty HTML page with SDK on it, and the Outreach app
+   * will load it early without the need for user interaction. That's how addon can update badge
+   * decoration and invite Outreach user to open full addon experience as defined in host.url property.
+   *
+   * Addons of AddonType.LeftSideMenu type can only use this property.
+   * For other addon types, this property will be ignored.
+   *
+   * @see https://github.com/getoutreach/clientxtsdk/blob/master/docs/manifest.md#notificationsUrl
+   * @type {string}
+   * @memberof ManifestHost
+   */
+  notificationsUrl?: string;
 }

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -144,6 +144,42 @@ describe('manifest tests', () => {
       expect(issues.length).toBe(1);
       expect(issues[0]).toBe('Host type  is invalid. Value: BANANAS');
     });
+
+    test('host.notificationUrl - is optional property', () => {
+      const manifest: Manifest = JSON.parse(JSON.stringify(validManifest));
+      delete manifest.host.notificationsUrl;
+      var issues = validate(manifest);
+      expect(issues.length).toBe(0);
+    });
+
+    test('host.notificationUrl - can be defined on addons other then left side menu extensions', () => {
+      const manifest: Manifest = JSON.parse(JSON.stringify(validManifest));
+      manifest.host.type = AddonType.AccountTab;
+      manifest.host.notificationsUrl = 'https://someurl.com/endpoint';
+      var issues = validate(manifest);
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe(
+        'Notifications url can be defined only for left-side-menu addon. Type: tab-account'
+      );
+    });
+
+    test('host.notificationUrl - only url should be acceptable', () => {
+      const manifest: Manifest = JSON.parse(JSON.stringify(validManifest));
+      manifest.host.type = AddonType.LeftSideMenu;
+      manifest.host.notificationsUrl = 'bananas';
+      var issues = validate(manifest);
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe(
+        'Notifications url definition is invalid url. Value: bananas'
+      );
+    });
+
+    test('host.notificationUrl - tokenized url should be acceptable', () => {
+      const manifest: Manifest = JSON.parse(JSON.stringify(validManifest));
+      manifest.host.url = 'https://tokenizedurl.com/{opp.id}?uid={usr.id}';
+      var issues = validate(manifest);
+      expect(issues.length).toBe(0);
+    });
   });
 
   describe('categories', () => {


### PR DESCRIPTION
Adds a new optional manifest property **host.notificationsUrl**

This is optional address of the endpoint serving notification centric version of the addon experience.

If defined, this endpoint will serve an empty HTML page with SDK on it, and the Outreach app will load it early without the need for user interaction. 
That's how addon can update badge decoration and invite Outreach user to open full addon experience as defined in host.url property.

Only addons of AddonType.LeftSideMenu type can only use this property.