### PR TITLE
#OREX-625 Invalidating current cookies

### DIFF
--- a/docs/outreach-api.md
+++ b/docs/outreach-api.md
@@ -41,12 +41,12 @@ As you can tell from the sequence diagram, there are a few steps "Add-on host AP
    - Check the browser local storage for a valid token
    - Call the  [token endpoint](#token-endpoint) with the current user id parameter, which returns user access token out of a valid cached access token or using the previously obtained refresh token.
 2. If no token available, addon renders a "Login with Outreach" button and in click handler of that button invokes **sdk.authorize()** function
-   - It will create a "cxt-sdk-user" cookie which will hold session state(userId) needed in next authorization step
+   - It will create a "cxt-sdk-user-v2" cookie which will hold session state(userId) needed in next authorization step
    - Addon opens popup using the Outreach [API authentication URL](https://api.outreach.io/api/v2/docs#authentication). Constructing of this url relies on manifest.api section configuration: [applicationId](manifest.md#applicationid), [redirectUri](manifest.md#redirecturi) and [scopes](manifest.md#scopes) values.
    - When user clicks **Authorize** button on [Outreach consent screen](assets/api-consent.png), Outreach will redirect to  **/authorize** endpoint on ([manifest.api.redirectUri](manifest.md#redirecturi)) address with a short living authorization code passed as query param.
 
 3. Host **authorize endpoint** will then:
-   - read the session context from request cookie "cxt-sdk-user": userId.
+   - read the session context from request cookie "cxt-sdk-user-v2": userId.
    - use received authorization code with Outreach app id and the secret to obtaining Outreach API access and refresh token
    - cache the retrieved tokens using a cache key with session userId value read from the cookie.
    - redirect to connect endpoint with access token and expiration passed as a query parameter
@@ -194,13 +194,13 @@ When the add-on host has obtained this data, it needs to store access and refres
 
 The add-on host needs to know the Outreach user for whom these tokens should be cached to be used later to implement the caching.
 
-Considering that [manifest api.redirectUri](manifest.md#redirectUri) can not contain state parameters, Outreach addons SDK stores current Outreach user identifier in **"cxt-sdk-user"** cookie at the start of sdk.authorize() implementation.
+Considering that [manifest api.redirectUri](manifest.md#redirectUri) can not contain state parameters, Outreach addons SDK stores current Outreach user identifier in **"cxt-sdk-user-v2"** cookie at the start of sdk.authorize() implementation.
 
 The add-on host implementing the caching should read from the cookie userId value and use it as a cache key for storing retrieved refresh and access tokens.
 
 #### Customizing the sdk user cookie
 
-The cxt-sdk-user cookie works because it is created on the domain where the addon is stored (e.g., "addon.some-host.com") through standard browser behavior, is sent to the api if the api endpoint is hosted on the same domain.
+The cxt-sdk-user-v2 cookie works because it is created on the domain where the addon is stored (e.g., "addon.some-host.com") through standard browser behavior, is sent to the api if the api endpoint is hosted on the same domain.
 Sometimes, the API is hosted in a different domain (e.g., "api.some-host.com"), and cookies sent on the addon domain will not be sent so that the OAuth flow will fail to [cache credentials](#caching-the-tokens).
 
 CXT sdk exposes a way to customize the domain to be used for context cookie to accommodate this - make sure cookie domain is set to api domain before starting authorization.
@@ -213,7 +213,7 @@ var token = await sdk.authenticate();
 
 In this example, both app.some-host.com and api.some-host.com have access to user cookie through the defined domain.
 
-(You can also change the cookie name (default: 'cxt-sdk-user') and max-age of the cookie (default: 1 hour)
+(You can also change the cookie name (default: 'cxt-sdk-user-v2') and max-age of the cookie (default: 1 hour)
 
 ### Passing back access token
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -216,7 +216,7 @@ This function addon calls anytime it needs a token to access Outreach API - no n
 
 This function will:
 
-- check if local storage has an item with key **cxt-sdk-token**
+- check if local storage has an item with key **cxt-sdk-token-v2**
 - it will check if the cached access token didn't expire
 - if the cached token is still active, the promise will resolve, and the addon creator will get a token.
 
@@ -238,4 +238,4 @@ If a sdk.getToken() function fails, addon creator has to show some clickable ele
 
 In case of an addon, the creator will call authorize() function after user-provided content. Outreach users will briefly see a popup being loaded and immediately closed after a very brief period.
 
-An important implementation detail of this function is that before a popup is shown, sdk will create a cookie called "cxt-sdk-token" where the user identifier will be stored so the addon host can read that value later for [caching tokens](outreach-api.md#caching-the-tokens) implementation.
+An important implementation detail of this function is that before a popup is shown, sdk will create a cookie called "cxt-sdk-token-v2" where the user identifier will be stored so the addon host can read that value later for [caching tokens](outreach-api.md#caching-the-tokens) implementation.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -216,7 +216,7 @@ This function addon calls anytime it needs a token to access Outreach API - no n
 
 This function will:
 
-- check if local storage has an item with key **cxt-sdk-token-v2**
+- check if local storage has an item with key **cxt-sdk-token**
 - it will check if the cached access token didn't expire
 - if the cached token is still active, the promise will resolve, and the addon creator will get a token.
 
@@ -238,4 +238,4 @@ If a sdk.getToken() function fails, addon creator has to show some clickable ele
 
 In case of an addon, the creator will call authorize() function after user-provided content. Outreach users will briefly see a popup being loaded and immediately closed after a very brief period.
 
-An important implementation detail of this function is that before a popup is shown, sdk will create a cookie called "cxt-sdk-token-v2" where the user identifier will be stored so the addon host can read that value later for [caching tokens](outreach-api.md#caching-the-tokens) implementation.
+An important implementation detail of this function is that before a popup is shown, sdk will create a cookie called "cxt-sdk-token" where the user identifier will be stored so the addon host can read that value later for [caching tokens](outreach-api.md#caching-the-tokens) implementation.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/client-addon-sdk",
   "license": "MIT",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ class AddonsSdk {
   public activeListener: boolean = false;
 
   /**
-   * Setting of the cookie cxt-sdk-user
+   * Setting of the cookie cxt-sdk-user-v2
    *
    * @see https://github.com/getoutreach/clientxtsdk/blob/main/docs/outreach-api.md#caching-the-tokens
    * @memberof AddonsSdk
@@ -798,10 +798,25 @@ class AddonsSdk {
     messageEvent: MessageEvent
   ) => {
     if (hostMessage.type !== AddonMessageType.INIT) {
+      this.logger.log({
+        origin: EventOrigin.ADDON,
+        type: EventType.INTERNAL,
+        level: LogLevel.Debug,
+        message: '[CXT][AddonSdk]::initializeOrigin- NO ORIGIN -> WRONG TYPE',
+        context: [JSON.stringify(hostMessage), JSON.stringify(messageEvent)],
+      });
       return null;
     }
 
     if (!utils.validHostOrigin(messageEvent.origin, this.logger)) {
+      this.logger.log({
+        origin: EventOrigin.ADDON,
+        type: EventType.INTERNAL,
+        level: LogLevel.Debug,
+        message:
+          '[CXT][AddonSdk]::initializeOrigin- NO ORIGIN -> INVALID HOST ORIGIN',
+        context: [JSON.stringify(messageEvent)],
+      });
       return null;
     }
 

--- a/src/sdk/Constants.ts
+++ b/src/sdk/Constants.ts
@@ -7,7 +7,7 @@ export class Constants {
    * @static
    * @memberof Constants
    */
-  public static AUTH_TOKEN_CACHE_KEY = 'cxt-sdk-token';
+  public static AUTH_TOKEN_CACHE_KEY = 'cxt-sdk-token-v2';
 
   /**
    * Name of the cookie storing the identifier of the
@@ -21,5 +21,5 @@ export class Constants {
    * @static
    * @memberof Constants
    */
-  public static AUTH_USER_STATE_COOKIE_NAME = 'cxt-sdk-user';
+  public static AUTH_USER_STATE_COOKIE_NAME = 'cxt-sdk-user-v2';
 }

--- a/src/sdk/Constants.ts
+++ b/src/sdk/Constants.ts
@@ -7,7 +7,7 @@ export class Constants {
    * @static
    * @memberof Constants
    */
-  public static AUTH_TOKEN_CACHE_KEY = 'cxt-sdk-token-v2';
+  public static AUTH_TOKEN_CACHE_KEY = 'cxt-sdk-token';
 
   /**
    * Name of the cookie storing the identifier of the


### PR DESCRIPTION
As we are changing the values stored in a cookie, old cookies with obsolete values have to be invalidated and one way to do that is to change the name of the cookie SDK is using.